### PR TITLE
Implementar PoC de Motor NLP Local

### DIFF
--- a/pocs/motor_nlp/poc_npl.py
+++ b/pocs/motor_nlp/poc_npl.py
@@ -1,0 +1,48 @@
+import json
+from langchain_community.llms import Ollama
+from langchain_core.prompts import PromptTemplate
+import time
+
+with open('amostra_para_luiz.json', 'r', encoding='utf-8') as f:
+    dados = json.load(f)
+    texto_discurso = dados['contexto_original']['texto_extraido']
+
+llm = Ollama(model="llama3", temperature=0.0)
+
+template = """
+Você é um analista de dados políticos. 
+Leia o discurso abaixo e extraia o tópico principal e a postura.
+
+REGRAS DE CLASSIFICAÇÃO:
+1. A postura (FAVORÁVEL, CONTRÁRIO, NEUTRO) deve ser ESTRITAMENTE em relação ao TÓPICO PRINCIPAL. 
+2. Se o orador for favorável ao tópico, mas atacar opositores ou outros partidos no meio do texto, a postura sobre o tópico continua sendo FAVORÁVEL. Ignore os ataques pessoais.
+
+Retorne APENAS um objeto JSON no formato exato: 
+{{"raciocinio": "sua explicacao breve em uma frase", "topico": "...", "postura": "..."}}
+Não escreva nenhuma palavra além do JSON.
+
+Discurso:
+{discurso}
+"""
+
+prompt = PromptTemplate.from_template(template)
+
+chain = prompt | llm
+
+print("Processando o discurso")
+resposta_texto = chain.invoke({"discurso": texto_discurso})
+
+try:
+    resultado_dict = json.loads(resposta_texto)
+    
+    if 'raciocinio' in resultado_dict:
+        del resultado_dict['raciocinio']
+    
+    json_final = json.dumps(resultado_dict, indent=2, ensure_ascii=False)
+    
+    print("\n--- Resultado da IA (Limpo) ---")
+    print(json_final)
+
+except json.JSONDecodeError:
+    print("\n[ERRO] A IA não retornou um JSON válido. Retorno bruto:")
+    print(resposta_texto)


### PR DESCRIPTION
## Descrição
Esta issue visa a criação de um script Python local que funcionará como uma Prova de Conceito (PoC) para o motor de Processamento de Linguagem Natural (NLP) do projeto. O script deve ser capaz de carregar textos brutos (discursos parlamentares), processá-los usando um modelo de linguagem local (como o Llama 3 via Ollama) e extrair metadados estruturados (tópico e postura).

## Objetivo
Validar a viabilidade técnica e a precisão da arquitetura de IA escolhida (local e offline) utilizando dados reais e autênticos da Câmara dos Deputados, antes de proceder com a integração em larga escala no pipeline de dados ou na nuvem. Isso inclui testes de performance e calibragem de engenharia de prompt.

## Requisitos (Critérios de Aceite)
requisitos que a issue deve ter pra ser considerada pronta
- [X] O script deve rodar localmente, sem depender de chamadas de API externas para inferência.
- [X] O script deve carregar e processar com sucesso o arquivo `.json` real fornecido pela equipe de dados (amostra autêntica).
- [X] O motor deve identificar corretamente o tópico e a postura do orador em >80% de uma amostra de teste.
- [X] A saída do script deve ser um JSON estruturado e válido, pronto para consumo pelo back-end.

## Prioridade
- [ ] **Baixa:** Não impacta o fluxo principal.
- [ ] **Média:** Necessária para a continuidade do projeto.
- [X] **Alta:** Impacto direto na entrega da sprint.
- [ ] **Urgente:** Bloqueia o time ou produção.

## Checklist de Tarefas
- [X] Configurar ambiente de desenvolvimento local (venv, langchain, ollama).
- [X] Instalar e configurar o motor local (Ollama e modelo Llama3).
- [X] Implementar o script core (leitura de arquivo, engenharia de prompt).
- [X] Implementar parser para o arquivo JSON de dados reais.
- [X] Validar resultados em amostras de teste.
- [X] Refinar prompts e parâmetros com base na validação.

## Responsável
@luizhtmoreira
