### PR TITLE
fix: padroniza saída do terminal para UTF-8

### DIFF
--- a/seeder_camara.py
+++ b/seeder_camara.py
@@ -1,6 +1,8 @@
+import sys
 import httpx
 from pprint import pprint
 
+sys.stdout.reconfigure(encoding='utf-8')
 BASE_URL = "https://dadosabertos.camara.leg.br/api/v2"
 
 def buscar_ultimo_discurso(id_camara):


### PR DESCRIPTION
**O que foi feito:** 
Adicionada a reconfiguração global do `sys.stdout` para UTF-8 no topo do `seeder_camara.py`.

**Por que foi feito:** 
Para corrigir o erro de `UnicodeEncodeError` ao imprimir caracteres especiais (emojis/acentos) em terminais Windows padrão.

**Impacto:** 
Garante que o script rode nativamente e sem erros em qualquer máquina da Squad, independente do sistema operacional, blindando a nossa infraestrutura.