### PR TITLE
Configuração do ambiente local com Docker (Next.js + FastAPI)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,14 @@ services:
       - .:/code
     env_file:
       - .env
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    environment:
+      - WATCHPACK_POLLING=true
+      - NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --verbose
+
+COPY . .
+
+CMD ["npm", "run", "dev"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.110.0
 uvicorn==0.29.0
 supabase==2.4.1
+fastapi-cache2
 python-dotenv==1.0.1


### PR DESCRIPTION
## Resumo
Esta PR finaliza a configuração da infraestrutura local do ContraDito utilizando Docker Compose, garantindo um ambiente padronizado e isolado para toda a Squad.

## O que foi feito:
- Criação do `Dockerfile` otimizado para o Frontend (Next.js) usando imagem Alpine.
- Atualização do `docker-compose.yml` para orquestrar API e Frontend na mesma rede.
- Configuração do **Hot Reload** no frontend via volume anônimo e variável *polling*.
- Correção crítica no `requirements.txt` do backend (adição da dependência `fastapi-cache2` que estava derrubando o build).

## Como a equipe deve testar localmente:
1. Certifique-se de criar o arquivo `.env` na raiz com as credenciais do Supabase.
2. Rode `docker-compose up --build` para forçar a atualização das dependências.
3. Acesse `http://localhost:3000` (Frontend) e `http://localhost:8000/docs` (API).