### PR TITLE
fix: ajusta versão do httpx para compatibilidade com supabase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvicorn==0.29.0
 supabase==2.4.1
 python-dotenv==1.0.1
 fastapi-cache2
-httpx==0.28.1
+httpx==0.27.2


### PR DESCRIPTION
## Descrição
Este PR resolve o erro de resolução de pacotes (`ResolutionImpossible`) que estava quebrando a configuração do ambiente local durante a execução do `pip install -r requirements.txt`. 

O problema ocorria porque a versão exigida pela biblioteca do Supabase (2.4.1) entrou em conflito com a versão do HTTPX fixada no repositório. O *downgrade* do pacote foi realizado para estabilizar a infraestrutura.

## Issue Relacionada
Resolves #63

## Alterações Realizadas
- Modificada a versão do `httpx` no arquivo `requirements.txt` de `0.28.1` para `0.27.2`.

## Como Testar
1. Baixe a branch localmente.
2. Rode `pip install -r requirements.txt`.
3. A instalação deve ser concluída com sucesso, sem erros de dependência.