### PR TITLE
(docs): atualização da arquitetura (RAG), cálculo de score, ADR 001 e Sprints 4 e 5

### DIFF
--- a/docs/docs/adrs/adr-001.md
+++ b/docs/docs/adrs/adr-001.md
@@ -1,0 +1,38 @@
+# ADR 001: Migração de Arquitetura Zero-Shot para RAG (Busca Vetorial)
+
+**Data:** 21/04/2026
+
+**Status:** Aceite (Implementado na Sprint 05)
+
+**Participantes:** @henriquemendeselias, @jot4-ge, @luizhtmoreira, @G2SBiell, @lucasaraujoszz, @matheus0346
+
+---
+
+## 1. Contexto e Problema
+
+O **ContraDito** iniciou com uma arquitetura onde o motor LLM (Llama 3 8B) atuava em formato *One-Shot/Zero-Shot*. O modelo recebia o texto bruto do discurso e deveria classificar o tema, inferir a postura e gerar um resumo em uma única requisição.
+
+Ao tentarmos escalar a base para os 513 deputados federais (Sprint 04), identificamos as seguintes falhas críticas:
+
+* **Sobrecarga Cognitiva:** O LLM não conseguia processar com precisão textos políticos altamente subjetivos, eufemísticos e longos.
+* **Inconsistência de Dados:** Ocorreram quebras frequentes na formatação de saída (JSON corrompido) e alucinações na correlação de contextos, gerando falsos positivos no Score de Coerência.
+
+## 2. Decisão Arquitetural
+
+Decidimos abandonar a classificação e extração via LLM direto e pivotar para uma arquitetura baseada em **Retrieval-Augmented Generation (RAG)**, adotando Busca Vetorial no banco de dados.
+
+As mudanças técnicas acordadas foram:
+
+1. **Modelos de Embeddings (SBERT):** Utilização do modelo `paraphrase-multilingual-mpnet-base-v2` no pipeline de extração para transformar leis e discursos limpos em vetores matemáticos de 768 dimensões.
+2. **Banco Vetorial:** Ativação da extensão `pgvector` no Supabase com criação de índices HNSW.
+3. **Filtro de Similaridade:** O cruzamento de dados ("Dito" vs "Feito") passa a ser calculado matematicamente via Similaridade de Cosseno diretamente no banco.
+4. **Redução do Escopo do LLM:** O Llama 3 deixa de atuar como motor de busca. Ele agora recebe apenas o par filtrado (Ementa da Lei + Discurso correspondente) e dedica 100% do processamento para justificar textualmente a postura (A Favor, Contra, Neutro).
+
+## 3. Consequências
+
+### Pontos Positivos:
+* **Alta Precisão e Rastreabilidade:** A eliminação de alucinações no cruzamento de dados, garantindo que o Score seja baseado em métricas matemáticas auditáveis.
+* **Performance:** A busca vetorial via índice HNSW é executada em milissegundos no banco de dados, aliviando a latência da API.
+
+### Trade-offs (Custos Adicionais):
+* **Complexidade de Infraestrutura:** Exigiu a reestruturação do `docker-compose` para isolar dependências pesadas de IA (PyTorch e Sentence-Transformers) em um contêiner separado (Worker ETL), além de adaptações no script de *seeding* (Upsert de texto limpo + vetor numérico).

--- a/docs/docs/arquitetura.md
+++ b/docs/docs/arquitetura.md
@@ -1,17 +1,19 @@
 # Arquitetura do Software
 
-Este documento detalha a estrutura técnica do projeto **ContraDito**, descrevendo os padrões de projeto, tecnologias e o fluxo de dados entre os componentes do sistema.
+Este documento detalha a estrutura técnica do projeto **ContraDito**, descrevendo os padrões de projeto, tecnologias e o fluxo de dados entre os componentes.
 
 ## 1. Visão Geral e Padrão Arquitetural
 
-O projeto utiliza o padrão **Pipe and Filter** (Cano e Filtro) para o seu pipeline de processamento de dados. Nesse modelo, os dados passam por uma série de componentes independentes (filtros) que transformam ou enriquecem a informação antes de passá-la para o próximo estágio.
+O projeto utiliza o padrão **Pipe and Filter** (Cano e Filtro) para o seu pipeline de processamento de dados. Nesse modelo, os dados passam por uma série de filtros que transformam a informação bruta da API da Câmara em uma análise de coerência política.
 
-### 1.1. O Pipeline de Dados do ContraDito:
-1.  **Extração (Source):** Scripts de raspagem coletam dados brutos da Câmara dos Deputados.
-2.  **Persistência Inicial:** Dados brutos são inseridos no Supabase.
-3.  **Processamento de IA (Filtro):** O Ollama processa os discursos, calcula o *score* de coerência e gera as justificativas.
-4.  **Enriquecimento (Filtro):** O banco de dados é atualizado com as análises da IA.
-5.  **Exibição (Sink):** A API FastAPI serve os dados processados para o Frontend em Next.js.
+### 1.1. O Pipeline de Dados Evoluído (RAG):
+Após o pivot técnico na Sprint 5, o pipeline foi reestruturado para utilizar **Busca Vetorial (Retrieval-Augmented Generation)**, abandonando o modelo *one-shot*:
+
+1.  **Extração e Higienização:** Scripts coletam dados da Câmara e utilizam **RegEx** para limpar ruídos e tags HTML.
+2.  **Vetorização (Embeddings):** O texto limpo é processado pelo modelo **SBERT** (`paraphrase-multilingual-mpnet-base-v2`), gerando vetores de **768 dimensões**.
+3.  **Persistência e Busca Vetorial:** Os dados e seus vetores são armazenados no **Supabase** com a extensão **`pgvector`**. O sistema realiza uma busca por **Similaridade de Cosseno** para cruzar leis e discursos.
+4.  **Inferência de Postura (Filtro IA):** O Llama 3 recebe apenas o contexto filtrado (Lei + Discurso relevante) para definir a postura (A Favor/Contra) e gerar a justificativa.
+5.  **Exibição (Sink):** A API FastAPI serve os resultados processados para o Frontend em Next.js/Streamlit.
 
 ---
 
@@ -19,43 +21,45 @@ O projeto utiliza o padrão **Pipe and Filter** (Cano e Filtro) para o seu pipel
 
 | Camada | Tecnologia | Responsabilidade |
 | :--- | :--- | :--- |
-| **Frontend** | React / Next.js | Interface do usuário e visualização de dados. |
-| **Backend** | FastAPI (Python) | Fornecimento da API REST e integração com o banco. |
-| **Banco de Dados** | Supabase (PostgreSQL) | Armazenamento persistente e Seeding de dados. |
-| **Inteligência Artificial** | Ollama / Llama 3 | Processamento de linguagem natural e cálculo de score. |
-| **Infraestrutura** | Docker / Docker Compose | Containerização e ambiente de desenvolvimento. |
-| **CI/CD** | GitHub Actions | Automação de Linter (Flake8/Black) e Deploy. |
+| **Frontend** | React / Next.js / Streamlit | Interface do usuário e visualização do Score de Coerência. |
+| **Backend** | FastAPI (Python) | Fornecimento da API REST e lógica de busca vetorial. |
+| **Banco de Dados** | Supabase + `pgvector` | Armazenamento persistente e busca por similaridade semântica (HNSW). |
+| **Inteligência Artificial** | SBERT & Llama 3 | Geração de embeddings e inferência de postura via RAG. |
+| **Infraestrutura** | Docker / Docker Compose | Containerização e isolamento de dependências pesadas (PyTorch). |
 
 ---
 
 ## 3. Componentes do Sistema
 
 ### 3.1. Backend (API)
-Desenvolvido em **FastAPI**, utiliza **Pydantic** para validação de contratos de dados.
-* **Rotas Principais:**
-    * `GET /politicos`: Listagem com filtros e paginação.
-    * `GET /politicos/{id}`: Detalhes completos, score e provas de contradição.
-* **Documentação:** Swagger integrado disponível em `/docs`.
+Desenvolvido em **FastAPI**, utiliza **Pydantic** para validação de contratos. É responsável por orquestrar a consulta ao banco vetorial e entregar o contexto para a IA.
 
-### 3.2. Frontend (Interface)
-Aplicação em **Next.js** focada em experiência do usuário (UX) e acessibilidade.
-* **Busca:** Filtros por partido, estado e cargo.
-* **Raio-X do Parlamentar:** Exibição visual do *Score de Coerência* e comparação lado a lado de discursos/votos.
+### 3.2. Inteligência Artificial (Análise Semântica)
+O motor de IA foi dividido em duas etapas para evitar a **Sobrecarga Cognitiva** observada em modelos *one-shot*:
 
-### 3.3. Inteligência Artificial (Análise)
-Utiliza o **Ollama** para processamento local de modelos de linguagem (LLM).
-* Analisa discursos inseridos no banco.
-* Gera *tags* e justifica as contradições detectadas.
-* Atualiza o campo `score_coerencia` no banco de dados.
+* **Embeddings:** Transforma discursos e leis em coordenadas matemáticas.
+* **RAG (Llama 3):** Atua apenas na etapa final, interpretando a relação entre os textos recuperados pelo banco.
 
-### 3.4. Banco de Dados
-Instância no **Supabase** que atua como o ponto central de integração entre o script de extração, a IA e o Backend.
+### 3.3. Banco de Dados e Busca Vetorial
+Instância no **Supabase** que utiliza a extensão `pgvector`. A utilização de índices **HNSW** permite que o sistema encontre contradições em milissegundos, cruzando a ementa de um projeto exclusivamente com os discursos do parlamentar que o votou.
 
 ---
 
-## 4. Integração e Deploy
+## 4. Evolução da Arquitetura: Do One-Shot ao RAG
 
-O projeto é totalmente containerizado via **Docker Compose**, permitindo que o Backend e o Frontend subam simultaneamente com um único comando, garantindo a paridade entre os ambientes de desenvolvimento e produção.
+Originalmente, o projeto tentou processar todas as informações em uma única chamada ao LLM (*One-Shot Prompting*). O modelo recebia o texto bruto e deveria classificar o tema, extrair o assunto e definir a postura simultaneamente.
 
-* **Linter:** Garantia de qualidade de código via GitHub Actions.
+**O Problema Encontrado:**
+Ao escalar para 513 deputados, o modelo apresentou alucinações e erros de formatação (JSON quebrado) por não conseguir processar o volume de discursos subjetivos de uma só vez.
+
+**A Solução Adotada:**
+Migramos para uma arquitetura de **Recuperação Vetorial**. Agora, o "trabalho pesado" de encontrar o discurso certo para a lei certa é feito matematicamente pelo banco de dados (Busca Vetorial). O LLM é acionado apenas para a análise final, garantindo precisão e eliminando alucinações.
+
+---
+
+## 5. Integração e Deploy
+
+O projeto é totalmente containerizado via **Docker Compose**, com as dependências de IA (PyTorch/Transformers) isoladas para garantir performance na API.
+
+* **Linter:** Garantia de qualidade via GitHub Actions.
 * **Pipeline:** Verificação automática em cada Pull Request para a branch `develop`.

--- a/docs/docs/calculo-score.md
+++ b/docs/docs/calculo-score.md
@@ -1,58 +1,57 @@
 # Como Calculamos o Score de Coerência
 
-O **Score de Coerência** é a principal métrica do ContraDito. Ele não é baseado em opiniões políticas, mas sim em um cruzamento analítico e matemático entre o **discurso público** (o que o político diz) e o **voto em plenário** (o que o político faz).
+O **Score de Coerência** é a principal métrica do ContraDito. Ele não é baseado em opiniões políticas, mas sim num cruzamento analítico, semântico e matemático entre o que o parlamentar afirma nos seus discursos e como ele efetivamente vota nos projetos de lei.
 
-Abaixo, detalhamos o passo a passo de como a nossa Inteligência Artificial e o nosso motor de regras chegam à nota final de cada parlamentar.
+Abaixo, detalhamos o passo a passo de como a nossa arquitetura de Inteligência Artificial e o nosso motor de busca vetorial chegam à nota final.
 
 ---
 
 ## O Fluxo de Cálculo (Passo a Passo)
 
-### 1. Extração de Entidades e Posicionamento (O "Dito")
-Primeiro, coletamos os discursos oficiais do parlamentar na Câmara dos Deputados. Nossa Inteligência Artificial (modelo LLM rodando via Ollama) lê o texto e extrai três informações cruciais:
-* **Tema/Tag:** Qual é o assunto principal? (ex: *Reforma Tributária*, *Privatização*, *Meio Ambiente*).
-* **Posicionamento:** Qual a postura do político sobre o tema? (A favor, Contra ou Neutro).
-* **Trecho (Evidência):** A frase exata que comprova esse posicionamento.
+### 1. Vetorização Semântica (O "Dito")
+Primeiro, coletamos os discursos oficiais do parlamentar na Câmara dos Deputados. Após a limpeza de ruídos, o texto não é classificado por tags rígidas. Utilizamos o modelo **SBERT** (`paraphrase-multilingual-mpnet-base-v2`) para converter o discurso num **Embedding** (um vetor matemático de 768 dimensões). 
+Este processo transforma o significado e a intenção da fala em coordenadas matemáticas, preservando nuances que uma simples tag ignoraria.
 
 ### 2. Mapeamento de Votos Oficiais (O "Feito")
-Em paralelo, nosso banco de dados mapeia como esse mesmo parlamentar votou (Sim, Não ou Abstenção) em Projetos de Lei (PLs) e emendas que possuem as mesmas **Tags** identificadas nos discursos.
+Em paralelo, o nosso banco de dados mapeia os votos oficiais (Sim, Não ou Abstenção) em Projetos de Lei (PLs). A ementa de cada projeto também é convertida num vetor matemático através do mesmo modelo de embeddings, garantindo que "Dito" e "Feito" falem a mesma linguagem matemática.
 
-### 3. O Cruzamento de Dados (O *Match*)
-O motor do ContraDito cruza a tag do discurso com a tag do voto e verifica a consistência:
-* **Coerência Positiva:** Discursou "A favor" e votou "Sim" (ou discursou "Contra" e votou "Não").
-* **Contradição (Incoerência):** Discursou "A favor" e votou "Não" (ou vice-versa).
-* **Abstenção/Neutralidade:** Avaliada caso a caso dependendo do impacto da votação.
+### 3. O Cruzamento Matemático (O *Match*)
+O motor do ContraDito utiliza a extensão **`pgvector`** no Supabase para calcular a **Similaridade de Cosseno** entre os vetores. 
+* Se a similaridade é alta, significa que o discurso e a lei tratam do mesmo assunto semântico.
+* O sistema recupera esse "par ideal" e aciona o **Llama 3** para confirmar a consistência:
+    * **Coerência Positiva:** O discurso defende a pauta e o voto foi favorável (ou vice-versa).
+    * **Contradição (Incoerência):** O discurso aponta para um lado, mas o voto registado foi na direção oposta.
 
 ### 4. A Fórmula Matemática do Score
-O *Score de Coerência* é uma nota de **[0 a 100]**, calculada com base no percentual de consistência entre os discursos e os votos atrelados à mesma tag. 
+O *Score de Coerência* é uma nota de **[0 a 100]**, calculada com base no percentual de consistência nos cruzamentos validados pela busca vetorial.
 
 *Fórmula simplificada:*
 **Score = (Total de Ações Coerentes / Total de Cruzamentos Válidos) * 100**
 
 *Exemplo Prático:*
-> Se o Deputado X possui 10 cruzamentos válidos (temas onde ele discursou E votou), e em 8 deles o voto seguiu o discurso, seu Score de Coerência será **80**. Os 2 casos divergentes serão listados no perfil dele como **"Provas da Contradição"**.
+> Se o sistema identificou 10 cruzamentos com alta similaridade semântica, e em 8 deles o parlamentar foi coerente entre fala e voto, o seu Score será **80**.
 
 ---
 
 ## Limitações e Mitigações
-Reconhecemos que a política é dinâmica e os políticos podem mudar de opinião ao longo do tempo. Para garantir justiça no cálculo:
-* **Fator Temporal:** Damos prioridade a cruzamentos de discursos e votos que ocorreram na mesma legislatura ou em um espaço de tempo próximo.
-* **Contexto da Votação:** Votos em "Destaques" ou manobras regimentais (que às vezes obrigam o político a votar "Não" no texto-base para aprovar uma emenda) são tratados com cautela pelo nosso modelo para evitar falsos positivos de contradição.
+Para garantir justiça e evitar punições por mudanças naturais de contexto:
+* **Fator Temporal:** Priorizamos cruzamentos entre discursos e votos próximos no tempo ou dentro da mesma legislatura.
+* **Contexto Político:** O motor LLM analisa se votos em "Destaques" ou manobras regimentais justificam uma aparente mudança de posicionamento, garantindo que a nota reflita a intenção real.
 
-### Os Bastidores do Passo 1: O Script de Extração (Seeder)
+---
 
-Para garantir que a Inteligência Artificial não perca tempo processando ruídos protocolares (como "Obrigado, Sr. Presidente" ou "Passo a palavra"), nosso script de extração em Python (`seeder.py`) atua como o primeiro filtro do sistema.
+## Os Bastidores do Passo 1: O Script de Extração (Seeder)
 
-Abaixo, destacamos as regras de negócio aplicadas direto no código antes mesmo do dado chegar ao banco:
+Para garantir que o processamento vetorial não seja prejudicado por ruídos protocolares (como "Obrigado, Sr. Presidente"), aplicamos regras de negócio diretamente no código de extração:
 
-1. **Filtro de Relevância (Tamanho do Texto):** O script consome a API da Câmara (`/deputados/{id}/discursos`) e ignora automaticamente qualquer transcrição que tenha menos de 150 caracteres.
-2. **Preparação para a IA:** O script cria o objeto do político inicializando o `score_coerencia` zerado e cria um registro na tabela `provas_contradicao` com os campos de análise (`topico_identificado`, `postura_extraida`, `voto_oficial`, `justificativa`) preenchidos como `None`. Estes "espaços em branco" são o gatilho para o processamento da Inteligência Artificial.
-3. **Idempotência (Upsert):** Utilizamos a função `.upsert()` do Supabase baseada no ID do parlamentar. Isso garante que o script possa ser rodado múltiplas vezes (rotina diária ou semanal) sem duplicar políticos ou discursos no banco de dados.
+1. **Filtro de Relevância:** O script ignora automaticamente qualquer transcrição excessivamente curta (abaixo de 150 caracteres).
+2. **Preparação de Dados:** O objeto do político é inicializado e as tabelas de provas são preparadas para receber os novos cruzamentos.
+3. **Idempotência (Upsert):** Utilizamos a função `.upsert()` para garantir que atualizações de discursos não gerem duplicidade de registros.
 
-**Trecho de destaque (Filtro de Ruído):**
+**Trecho de destaque (Filtro de Ruído em Python):**
 ```python
 def buscar_ultimo_discurso_relevante(id_camara):
-    # ... (código de conexão com a API omitido para brevidade) ...
+    # ... (conexão com API) ...
     for discurso in dados:
         texto = discurso.get("transcricao", "")
         data_hora = discurso.get("dataHoraInicio", "2023-01-01T00:00").split("T")[0]
@@ -61,4 +60,4 @@ def buscar_ultimo_discurso_relevante(id_camara):
         if len(texto) > 150:
             return texto, data_hora
 
-    return "Nenhum discurso relevante encontrado após aplicar os filtros.", "2023-01-01"
+    return "Nenhum discurso relevante encontrado.", "2023-01-01"

--- a/docs/docs/sprints/sprint-4.md
+++ b/docs/docs/sprints/sprint-4.md
@@ -1,0 +1,47 @@
+# Sprint 4 - Escala, Benchmarking e o Pivot Arquitetural
+
+**Período:** 14/04/2026 a 21/04/2026
+
+## Descrição
+A Sprint 04 começou com o objetivo de escalar a base de dados (para os 513 deputados) e aprimorar a interface com base em benchmarking de mercado. No entanto, o aumento da carga de dados expôs limitações críticas na arquitetura inicial da IA. Isso forçou a equipe a realizar um diagnóstico profundo e um *pivot* arquitetural de emergência, mudando a forma como o sistema processa e cruza os dados.
+
+## Benchmarking e UX
+A equipe consultou o portal **"Ranking dos Políticos"** para realizar um estudo de usabilidade. O objetivo foi mapear boas práticas de design para a exibição clara do Score de Coerência e inspirar os novos wireframes do Front-end.
+
+## Backlog Original da Sprint (Planejamento)
+| Tarefa | Responsável | Status |
+| :--- | :--- | :--- |
+| **API:** Implementação de ordenação por score e cache nas rotas. | @henriquemendeselias | [x] Concluído |
+| **Extração:** Ajuste no script (Seeder) para extrair os 513 deputados e filtrar ruído. | @jot4-ge | [x] Concluído |
+| **IA:** *Fine-tuning* do prompt para evitar alucinações. | @luizhtmoreira | [x] Concluído (Gerou o Pivot) |
+| **Front-end:** Wireframes das páginas do site. | @G2SBiell | [x] Concluído |
+| **Infra:** Manutenção preventiva do docker-compose e script de backup. | @lucasaraujoszz | [x] Concluído |
+| **Documentação:** Explicação do cálculo do score de coerência. | @matheus0346 | [x] Concluído |
+
+---
+
+## O Diagnóstico Técnico (O Problema)
+Ao tentar aplicar o LLM (Llama 3 8B) operando de forma linear sobre a base completa de 513 deputados, identificamos uma falha crítica:
+* **Sobrecarga Cognitiva:** Tentar enquadrar discursos políticos (que são altamente subjetivos e cheios de eufemismos) em categorias temáticas rígidas (ex: Economia, Saúde) forçava o modelo a "adivinhar" o contexto da fala.
+* **Inconsistências:** Essa sobrecarga gerava *parse errors* na formatação de saída (JSON) e alucinações na correlação de contexto, tornando a auditoria da coerência política pouco confiável.
+
+## Decisões Arquiteturais (A Solução)
+Na reunião extraordinária do dia 20/04, a equipe decidiu abandonar a classificação discreta de tópicos e pivotar para uma arquitetura baseada em **Recuperação Vetorial (RAG)**. 
+
+O projeto manteve a macroarquitetura *Pipe and Filter*, mas os filtros internos de IA foram reestruturados com as seguintes decisões:
+
+1. **Adoção do SBERT (Embeddings):** A classificação de tópicos e a extração de assuntos, que antes eram feitas de uma só vez pelo Llama (*one-shot prompting*), foram substituídas por modelos de similaridade semântica para português (`paraphrase-multilingual-mpnet-base-v2`). Textos de leis e discursos passam a ser transformados em vetores matemáticos (arrays de 768 dimensões) localmente.
+2. **Supabase como Banco Vetorial:** Ativação da extensão `pgvector` com índices HNSW. A busca cruza a ementa da lei exclusivamente com os discursos do parlamentar que votou, via matemática pura (Similaridade de Cosseno), eliminando falsos positivos.
+3. **Redução do Escopo do LLM:** O Llama 3 deixa de atuar como classificador de temas. Ele passa a receber o par exato selecionado pela busca vetorial (Lei + Discurso), focando 100% de sua capacidade em inferir a intenção e a postura (A FAVOR, CONTRA, NEUTRO).
+
+---
+
+## Reuniões
+
+### 1. Planejamento da Sprint 04
+* **Data:** 14/04/2026
+* **Ata:** Definição do escopo de escala para 513 deputados, estudo de benchmarking ("Ranking dos Políticos") e delegação das frentes de trabalho.
+
+### 2. Reunião Extraordinária (Pivot Arquitetural)
+* **Data:** 20/04/2026
+* **Ata:** Reunião emergencial focada em diagnosticar os erros do Llama 3. A equipe oficializou a transição para a Busca Vetorial descrita acima, com as tarefas de refatoração do banco e dos scripts movidas diretamente para o Backlog da Sprint 05.

--- a/docs/docs/sprints/sprint-5.md
+++ b/docs/docs/sprints/sprint-5.md
@@ -1,0 +1,21 @@
+# Sprint 5 - Implementação da Arquitetura Vetorial (RAG)
+
+**Período:** 21/04/2026 a 28/04/2026
+
+## Descrição
+Esta Sprint é dedicada à reestruturação técnica do motor de Inteligência Artificial do **ContraDito**, conforme decidido no diagnóstico do dia 20/04. O foco sai da classificação genérica por LLM e entra na **Busca Vetorial de Precisão**, utilizando embeddings de 768 dimensões e a extensão `pgvector` no Supabase para garantir que as contradições sejam detectadas com base em similaridade semântica real.
+
+## Backlog da Sprint
+| Tarefa | Responsável | Status |
+| :--- | :--- | :--- |
+| **Banco e API:** Ativação do `pgvector`, migrations de colunas de embedding e índice HNSW. Refatoração da lógica de consulta. | @henriquemendeselias | [ ] A fazer |
+| **ETL e Higienização:** Limpeza de dados com RegEx e integração do gerador de vetores no fluxo de extração. | @jot4-ge | [ ] A fazer |
+| **Motor de Embeddings:** Script PoC com `sentence-transformers` (modelo multilingual) e teste de similaridade de cosseno. | @luizhtmoreira | [ ] A fazer |
+| **UX/UI Refactor:** Redesenho da interface para o confronto "Projeto vs. Discurso" e adaptação para justificativas da IA. | @G2SBiell | [ ] A fazer |
+| **Infra/Docker:** Isolamento de dependências pesadas (PyTorch/SBERT) em contêiner de Worker e setup do banco vetorial local. | @lucasaraujoszz | [ ] A fazer |
+| **Documentação:** Redação do ADR 001 e atualização das páginas de Arquitetura e Cálculo do Score. | @matheus0346 | [ ] A fazer |
+
+## Reuniões
+### Planejamento da Sprint 05
+* **Data:** 21/04/2026 (14:00h)
+* **Ata:** Revisamos a falha da Sprint 04 e detalhamos as tarefas técnicas para a virada de chave para o RAG. O time concordou que a prioridade é a estabilização do banco vetorial no Dia 2 da Sprint, Alem disso começamos 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,6 +14,8 @@ nav:
   - Home: index.md
   - Transparência e LGPD: lgpd.md
   - Arquitetura: arquitetura.md
+  - Decisões Arquiteturais (ADRs):
+      - ADR 001 - RAG e Vetores: adrs/adr-001.md
   - Como Calculamos o Score: calculo-score.md
   - Como executar o projeto?: execucao.md
   - Sprints:
@@ -21,6 +23,8 @@ nav:
       - Sprint 1: sprints/sprint-1.md
       - Sprint 2: sprints/sprint-2.md
       - Sprint 3: sprints/sprint-3.md
+      - Sprint 4: sprints/sprint-4.md
+      - Sprint 5: sprints/sprint-5.md
   - API: api.md
 
 extra_css:


### PR DESCRIPTION
**Descrição:**

###  O que foi feito?
Este PR foca na atualização de toda a documentação técnica do projeto para refletir o pivot arquitetural decidido na reunião extraordinária do dia 20/04/2026. A documentação descreve agora a transição do modelo de classificação *One-Shot* (Llama 3) para a nova arquitetura baseada em **Busca Vetorial (RAG)**.

###  Principais Alterações:
* **`arquitetura.md`**: Atualizado para a Versão 2.0. Adicionada a explicação do novo pipeline com o uso do SBERT para embeddings e o `pgvector` do Supabase. O histórico da arquitetura antiga foi mantido para fins de comparação.
* **`calculo-score.md`**: Metodologia reescrita para clarificar que o cálculo não é mais uma nota subjetiva da IA, mas sim uma métrica matemática (Similaridade de Cosseno via índice HNSW).
* **`docs/docs/adrs/adr-001.md`**: Criação do documento que formaliza a decisão de abandonar o *Zero-Shot* devido à sobrecarga cognitiva do Llama 3 e a adoção do RAG.
* **`sprints/sprint-4.md` e `sprint-5.md`**: Relatórios das Sprints criados/atualizados, documentando o diagnóstico da falha na escala para 513 deputados e o planeamento da nova esteira vetorial.
* **`mkdocs.yml`**: Menu de navegação lateral atualizado para incluir a aba de ADRs e as novas Sprints.

###  Contexto (Sprint 05)
Estas alterações cumprem o backlog designado a mim (@matheus0346) na Sprint 05, garantindo que o repositório de documentação (MkDocs) esteja 100% alinhado com o código da nova engine de IA do ContraDito.