### PR TITLE
fix(infra): adiciona venv e node_modules no dockerignore para acelerar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,11 @@ extrair_amostras.py
 parsear_amostras.py
 pocs/
 seeder_camara.py
+venv/
+.venv/
+env/
+
+node_modules/
+frontend/node_modules/
+
+.next/


### PR DESCRIPTION
🚀 O que foi feito?

Adicionadas as pastas de ambientes virtuais locais (venv, .venv, env) e de dependências do frontend (node_modules, .next) no arquivo .dockerignore.

🐛 Por que foi feito?

Antes, ao rodar docker compose up --build, o Docker estava copiando centenas de megabytes (ou até gigabytes) de arquivos inúteis da máquina local para o build context antes de sequer começar a ler o Dockerfile. Isso fazia o comando demorar de 1 a 2 minutos toda vez.

Com essa correção, blindamos o Docker para ignorar o "lixo local". A etapa de transferência de contexto agora é quase instantânea.

🧪 Como a equipe pode testar?

Baixe esta branch ou puxe a develop após o merge.

Rode docker compose up --build.

O terminal não vai mais ficar travado processando arquivos, e o cache do Docker será respeitado em poucos segundos!