### PR TITLE
Chore/claude code config

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**ContraDito** is a political transparency platform that cross-references Brazilian federal legislators' speeches against their voting records, computing a **Score de Coerência** (Coherence Score) using AI. It is an academic project for the MDS discipline at UnB (Universidade de Brasília).
+
+## Running the Project
+
+All services run via Docker Compose. Requires a `.env` file at the root:
+
+```env
+SUPABASE_URL=...
+SUPABASE_KEY=...
+LLM_PROVIDER=groq   # "groq" or "colab"
+GROQ_API_KEY=...
+REDIS_URL=redis://redis:6379
+NEXT_PUBLIC_API_URL=http://localhost:8001
+```
+
+```bash
+docker compose up --build
+```
+
+- API docs (FastAPI Swagger): http://localhost:8001/docs
+- PostgreSQL: localhost:5432
+
+> On Apple Silicon (ARM64): ensure `platform: linux/arm64` is set in `docker-compose.yml`. The first build downloads the HuggingFace model (~2.3GB) and caches it in a Docker volume.
+
+## Linting (CI enforced on PRs to `develop` and `main`)
+
+```bash
+# Format check
+black --check app/
+
+# Lint (critical errors only)
+flake8 app/ --count --select=E9,F63,F7,F82 --show-source --statistics
+
+## Architecture
+
+The system is a strict **CQRS** pattern split into two isolated Python services:
+
+### Read Side — `app/` (FastAPI, port 8000)
+- Entry point: `app/main.py`
+- Routes: `app/rotas/politicos.py` and `app/rotas/logs.py`
+- Pydantic schemas: `app/modelos/schemas.py`
+- Supabase client: `app/bancos/supabase.py`
+- Uses `fastapi-cache2` with `InMemoryBackend` (1h TTL on list endpoints)
+- Rate-limited via `slowapi` (5/min on semantic search)
+- CORS is locked to `http://localhost:3000`
+
+Key internal routes (hidden from Swagger):
+- `POST /api/politicos/interno/recalcular-scores` — recalculates all coherence scores from `provas_contradicao` table
+- `POST /api/politicos/interno/limpar-cache` — invalidates the in-memory cache (called by the ETL worker after writes)
+
+### Write Side — `worker_api.py` (FastAPI, port 8001, internal only)
+- Entry point: `worker_api.py`
+- Exposes a single route: `POST /gerar-embedding`
+- NLP engine: `utils/motor_nlp.py` — wraps `sentence-transformers` model `paraphrase-multilingual-mpnet-base-v2` (768-dimension vectors)
+- Port 8001 is **not exposed externally** (Docker-internal only); the API calls it via `http://worker:8001`
+
+### Database — Supabase (PostgreSQL + pgvector)
+Core tables:
+- `politicos` — legislators with `score_coerencia` field
+- `provas_contradicao` — AI-generated contradiction evidence, one row per speech/vote pair, with `status_coerencia` (bool)
+- `logs_pipeline_ia` — ETL error log
+- Vector similarity search uses a Supabase RPC `buscar_discursos_similares` (stored procedure using `pgvector`)
+
+In local Docker, the DB is `pgvector/pgvector:pg15` on port 5432 (exposed for DBeaver/pgAdmin inspection).
+
+### Frontend — `frontend/` (Next.js 16 + React 19 + Tailwind CSS 4)
+- App Router under `frontend/app/`
+- Pages: `/` (listing), `/politico/[id]` (profile), `/comparacao` (comparison)
+- Communicates with the API at `NEXT_PUBLIC_API_URL`
+
+## Score de Coerência Logic
+
+Defined in `app/rotas/politicos.py:recalcular_todos_scores`:
+- Abstentions/absences (`AUSENTE`, `ABSTENÇÃO`, `NÃO COMPARECEU`, etc.) are excluded from the denominator (RF27)
+- Minimum of **3 valid votes** required to produce a non-null score (RF15)
+- Score = `(votos_coerentes / total_validos) * 100`, rounded to 1 decimal

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,67 @@
+# ContraDito
+
+Plataforma de transparência política que cruza discursos e votos de parlamentares brasileiros, calculando um Score de Coerência com IA.
+
+## Language
+
+### Parlamentares
+
+**Parlamentar**:
+Deputado Federal ou Senador rastreado pelo sistema.
+_Avoid_: Político, candidato.
+
+**Dossiê**:
+Página de perfil detalhado de um parlamentar (`/politico/[id]`), organizada em três abas — Perfil, Votações e Similares.
+_Avoid_: Perfil, página do político.
+
+**Status do Mandato**:
+Estado atual do exercício do cargo (ex: "Em Exercício", "Licenciado"). Distinto de cargo ou partido.
+_Avoid_: Situação.
+
+### Votos e Coerência
+
+**Votação Analisada**:
+Um `Voto` onde a IA encontrou discurso suficiente e produziu um veredito (`eh_coerente IS NOT NULL`). Apenas votações analisadas entram no denominador do Score e na Timeline.
+_Avoid_: Votação válida, prova de contradição.
+
+**Score de Coerência**:
+Percentual (0–100, uma casa decimal) de votações analisadas onde o parlamentar votou em linha com seus discursos. Nulo quando há menos de 3 votações analisadas.
+_Avoid_: Índice de coerência, nota.
+
+**Timeline de Coerência**:
+Série cronológica do Score de Coerência acumulado, onde cada ponto representa uma votação analisada. O score de cada ponto é calculado considerando todas as votações analisadas até aquela data.
+_Avoid_: Histórico de coerência, gráfico de evolução.
+
+**Concordância**:
+Percentual de proposições em que dois parlamentares votaram identicamente (somente votos "Sim" e "Não"). Requer mínimo de 5 proposições em comum para ser calculada.
+_Avoid_: Similaridade, alinhamento.
+
+**Dados Suficientes**:
+Condição em que um parlamentar possui ao menos 3 votações analisadas, habilitando cálculo de Score e exibição no ranking ordenado. Abaixo desse limiar, métricas são exibidas com denominador explícito (ex: "100% — 1 votação") e o parlamentar é excluído do ranking por padrão (visível via toggle).
+_Avoid_: Dados válidos, threshold mínimo.
+
+**Taxa de Presença**:
+Percentual de votações registradas (incluindo ausências) em que o parlamentar efetivamente votou (voto_oficial ≠ "Ausente" / "NÃO COMPARECEU"). Denominador distinto do Score de Coerência, que usa apenas votações analisadas.
+_Avoid_: Frequência, assiduidade.
+
+**Benchmark de Coerência**:
+Contexto comparativo exibido no Dossiê (aba Perfil) junto ao Score de Coerência. Compara o score do parlamentar contra dois referenciais: média do partido (primária) e média do cargo (secundária). Calculado apenas sobre parlamentares com Dados Suficientes.
+_Avoid_: Média geral, ranking comparativo.
+
+**Tendência Recente**:
+Indicador de momentum calculado no frontend a partir da Timeline de Coerência. Compara o score acumulado das últimas 10 votações analisadas contra o score histórico total. Exibido apenas quando o parlamentar possui ao menos 15 votações analisadas. Aparece no Dossiê (aba Perfil) e na página de Comparação.
+_Avoid_: Histórico recente, evolução curta.
+
+**Parlamentar Similar**:
+Parlamentar que apresenta alta concordância com outro, com ao menos 5 proposições analisadas em comum.
+_Avoid_: Parlamentar aliado, votante parecido.
+
+### Proposições
+
+**Proposição**:
+Projeto de Lei (PL) ou Proposta de Emenda à Constituição (PEC) com votação nominal registrada no período 2023–2026.
+_Avoid_: Lei, matéria, projeto.
+
+**Resumo Executivo**:
+Síntese temática de uma Proposição gerada pelo LLM (Llama 3.1), limitada a 512 tokens, usada como base para vetorização semântica.
+_Avoid_: Ementa, sumário.


### PR DESCRIPTION
## O que esse PR adiciona
- `CLAUDE.md` com visão geral do projeto, arquitetura, stack e convenções para desenvolvimento assistido por IA
- `CONTEXT.md` com glossário do domínio do ContraDito
- Skill `frontend-design` — guia o Claude para gerar interfaces production-grade com identidade visual forte
- `grill-with-docs` — sessão de perguntas para stress-testar planos contra o modelo de domínio e manter documentação viva

## Por que agora
Configuração trazida da branch `Teste_front` para que todo o time passe a usar o Claude Code com contexto compartilhado do projeto.

## Como usar
Basta ter o Claude Code instalado e abrir o projeto — o `CLAUDE.md` é lido automaticamente em toda sessão.