### PR TITLE
infra(docker): configura polling do hot-reload, fixa tag do mkdocs

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,20 +1,49 @@
-FROM python:3.12-slim
+# =================================================================
+# Estágio 1: 'base' - Imagem python com utilitários
+# =================================================================
+FROM python:3.12-slim as base
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Instala o curl para o healthcheck no docker-compose
+# Instala o curl, necessário para o healthcheck definido no docker-compose.yml
 RUN apt-get update && apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY requirements.api.txt .
+# =================================================================
+# Estágio 2: 'builder_prod' - Instala apenas dependências de PRODUÇÃO
+# =================================================================
+FROM base as builder_prod
 
+COPY requirements.api.txt .
 RUN pip install --no-cache-dir -r requirements.api.txt
+
+# =================================================================
+# Estágio 3: 'test' - Adiciona dependências de TESTE e define o comando
+# Para executar os testes: docker build --target test .
+# =================================================================
+FROM builder_prod as test
+
+COPY requirements.test.txt .
+RUN pip install --no-cache-dir -r requirements.test.txt
 
 COPY . .
 
-EXPOSE 8000
+# O comando `pytest` será executado no diretório raiz do projeto
+CMD ["pytest"]
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# =================================================================
+# Estágio 4: 'production' (final) - Imagem de produção enxuta
+# Esta é a imagem construída por padrão pelo `docker compose build`
+# =================================================================
+FROM base as production
+
+# Copia apenas os pacotes de produção pré-instalados do estágio 'builder_prod'
+COPY --from=builder_prod /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder_prod /usr/local/bin /usr/local/bin
+
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,7 @@
-FROM python:3.12-slim
+# =================================================================
+# Estágio 1: 'base' - Imagem python
+# =================================================================
+FROM python:3.12-slim as base
 
 WORKDIR /app
 
@@ -6,19 +9,48 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# 1. Camada 1: Dependências de IA (PyTorch, Sentence-Transformers, Langchain)
-# Estas mudam muito raramente, isolá-las otimiza builds em 90% do tempo.
-RUN pip install --no-cache-dir torch sentence-transformers langchain-core langchain-ollama --extra-index-url https://download.pytorch.org/whl/cpu
+# =================================================================
+# Estágio 2: 'builder_prod' - Instala apenas dependências de PRODUÇÃO
+# Preserva o cache em camadas original para builds ágeis.
+# =================================================================
+FROM base as builder_prod
 
-# 2. Camada 2: Dependências de parsing de PDF e higienização (conforme arquitetura)
+# Camada 1: Dependências de IA (PyTorch, Sentence-Transformers, Langchain)
+RUN pip install --no-cache-dir torch sentence-transformers langchain-core --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Camada 2: Dependências de parsing de PDF e higienização
 RUN pip install --no-cache-dir pdfplumber beautifulsoup4
 
-# 3. Camada 3: Demais dependências dinâmicas do projeto (Supabase, FastAPI, Redis, etc)
+# Camada 3: Demais dependências de produção do projeto
 COPY requirements.worker.txt .
-RUN pip install --no-cache-dir -r requirements.worker.txt
+RUN grep -v "google-genai" requirements.worker.txt > temp_requirements.txt && \
+    pip install --no-cache-dir -r temp_requirements.txt && \
+    pip install --no-cache-dir "google-genai==2.8.0" && \
+    rm temp_requirements.txt
 
-# 4. Camada 4: Código-fonte da aplicação
+# =================================================================
+# Estágio 3: 'test' - Adiciona dependências de TESTE e define o comando
+# Para executar os testes: docker build --target test -f Dockerfile.worker .
+# =================================================================
+FROM builder_prod as test
+
+COPY requirements.test.txt .
+RUN pip install --no-cache-dir -r requirements.test.txt
+
 COPY . .
 
-# O Entrypoint fica delegado ao docker-compose (cron / exec manual)
+# O comando `pytest` será executado no diretório raiz do projeto
+CMD ["pytest"]
+
+# =================================================================
+# Estágio 4: 'production' (final) - Imagem de produção enxuta
+# Esta é a imagem construída por padrão pelo `docker compose build`
+# =================================================================
+FROM base as production
+
+# Copia apenas os pacotes de produção pré-instalados do estágio 'builder_prod'
+COPY --from=builder_prod /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder_prod /usr/local/bin /usr/local/bin
+
+COPY . .
 CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   redis:
     image: redis:alpine
-    platform: linux/arm64
     networks:
       - read
       - write
@@ -16,7 +15,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.api
-    platform: linux/arm64
     restart: unless-stopped
     ports:
       - "127.0.0.1:8001:8000"
@@ -28,6 +26,7 @@ services:
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_KEY=${SUPABASE_KEY}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - WATCHFILES_FORCE_POLLING=true
     depends_on:
       redis:
         condition: service_healthy
@@ -43,7 +42,6 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    platform: linux/arm64
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
@@ -55,6 +53,8 @@ services:
     environment:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8001}
       - API_INTERNAL_URL=${API_INTERNAL_URL:-http://fastapi:8000}
+      - WATCHPACK_POLLING=true
+      - CHOKIDAR_USEPOLLING=true
     depends_on:
       fastapi:
         condition: service_healthy
@@ -63,7 +63,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.worker
-    platform: linux/arm64
     networks:
       - write
     volumes:
@@ -72,9 +71,9 @@ services:
     environment:
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_KEY=${SUPABASE_KEY}
-      - LLM_PROVIDER=${LLM_PROVIDER:-groq}
-      - GROQ_API_KEY=${GROQ_API_KEY}
-      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL}
+      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_API_KEY=${QDRANT_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379}
     depends_on:
       redis:
@@ -87,6 +86,52 @@ services:
     # Mantém o contêiner em modo ocioso para permitir a execução manual via `docker compose run` 
     # ou cron jobs internos, sem fechar imediatamente o contêiner no compose up.
     command: ["tail", "-f", "/dev/null"]
+
+  # =================================================================
+  # Serviços de Teste (executados apenas com --profile test)
+  # =================================================================
+  test-api:
+    profiles:
+      - test
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+      target: test
+    networks:
+      - read
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  test-worker:
+    profiles:
+      - test
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+      target: test
+    networks:
+      - write
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
+      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_API_KEY=${QDRANT_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+
+  docs:
+    image: squidfunk/mkdocs-material:9.5.18
+    ports:
+      - "127.0.0.1:8002:8000"
+    volumes:
+      - ./docs:/docs
+    environment:
+      - MKDOCS_WATCHDOG_USE_POLLING=true
 
 networks:
   read:

--- a/docs/docs/execucao.md
+++ b/docs/docs/execucao.md
@@ -8,16 +8,17 @@ Este documento descreve as decisões arquiteturais que governam a infraestrutura
 
 A infraestrutura é orquestrada via Docker Compose. Os bancos de dados **não são contêineres** — utilizamos o Supabase (relacional) e o Qdrant (vetorial) como serviços externos em nuvem, e toda persistência de dados e vetores é responsabilidade deles.
 
-Os contêineres locais são exatamente quatro:
+Os contêineres locais são exatamente cinco:
 
 | Contêiner | Tecnologia | Porta exposta no host |
 |---|---|---|
 | `nextjs` | Next.js (Node.js 20) | `3000` |
-| `fastapi` | FastAPI (Python 3.12) | `8000` |
+| `fastapi` | FastAPI (Python 3.12) | `8001` |
 | `worker` | Python 3.12 + PyTorch + BAAI/bge-m3 | **Nenhuma** |
 | `redis` | Redis Alpine | **Nenhuma** |
+| `docs` | MkDocs Material | `8002` |
 
-O Worker não expõe portas — é disparado por cron job e opera completamente isolado do tráfego web. O Redis também é exclusivamente um canal interno de comunicação assíncrona.
+O Worker e o Redis não expõem portas diretamente no host (sendo de uso estritamente interno e isolado). O contêiner `docs` é totalmente isolado de rede e serve apenas para a visualização da documentação local.
 
 ---
 
@@ -48,7 +49,7 @@ flowchart TB
 
     EXT1[("Supabase\nRelacional (Nuvem)")]
     EXT2[("Qdrant\nVetorial (Nuvem)")]
-    EXT3[("Groq / Colab\nLLM Externo")]
+    EXT3[("Gemini API\nLLM Externo")]
 
     NX -->|HTTP| FA
     FA <-->|sub / pub| RD
@@ -71,13 +72,11 @@ Como ambos os bancos são serviços externos, nenhum volume Docker adicional é 
 
 > Para detalhes sobre o Supabase como plataforma e o modelo de persistência relacional, consulte a [Visão Geral da Arquitetura](arquitetura.md).
 
-### 2.3 Motor de Inferência externo — troca de provedor via `.env`
+### 2.3 Motor de Inferência externo — Gemini API via `.env`
 
-O Motor de Inferência não é um contêiner local. O provedor é selecionado pela variável de ambiente `LLM_PROVIDER`, **sem nenhuma alteração em Dockerfile ou `docker-compose.yml`**.
+O Motor de Inferência não é um contêiner local. Ele utiliza diretamente a API oficial do Gemini (`gemini-2.5-flash-lite`) como serviço externo em nuvem.
 
-O Worker acessa o provedor exclusivamente via egress HTTPS a partir da rede `write`.
-
-> Para detalhes sobre os provedores (Groq, Colab/Ollama) e estratégia híbrida, consulte a [Visão Geral da Arquitetura](arquitetura.md).
+O Worker acessa a API do Gemini exclusivamente por meio de chamadas HTTPS a partir da rede `write`, autenticando-se com a variável `GEMINI_API_KEY` injetada via `.env`.
 
 ### 2.4 Volumes — cache HuggingFace
 
@@ -156,27 +155,25 @@ SUPABASE_KEY=
 QDRANT_URL=
 QDRANT_API_KEY=
 
-# Motor de Inferência — seletor de provedor (obrigatório para Worker)
-LLM_PROVIDER=          # "groq" ou "colab"
-GROQ_API_KEY=          # obrigatório quando LLM_PROVIDER=groq
-OLLAMA_BASE_URL=       # obrigatório quando LLM_PROVIDER=colab — atualizar a cada sessão
+# Motor de Inferência — API do Gemini (obrigatório para Worker)
+GEMINI_API_KEY=
 
 # Redis — canal de invalidação de cache
 REDIS_URL=redis://redis:6379
 
 # Front-end
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost:8001
 ```
 
 !!! danger "Atenção"
-    `OLLAMA_BASE_URL` não deve ter valor padrão. A ausência do valor quando `LLM_PROVIDER=colab` deve gerar erro explícito no Worker, não falha silenciosa. `REDIS_URL` é consumida pela FastAPI e pelo Worker — ambos devem falhar explicitamente se estiver ausente. `QDRANT_URL` e `QDRANT_API_KEY` são obrigatórias para o Worker — a ausência de qualquer uma deve gerar erro explícito antes de iniciar o pipeline de vetorização.
+    `GEMINI_API_KEY` não possui valor padrão e é obrigatória para o funcionamento das análises de IA do Worker. `REDIS_URL` é consumida pela FastAPI e pelo Worker — ambos devem falhar explicitamente se estiver ausente. `QDRANT_URL` e `QDRANT_API_KEY` são obrigatórias para o Worker — a ausência de qualquer uma deve gerar erro explícito antes de iniciar o pipeline de vetorização.
 
 ---
 
 ## 4. Guia de Execução Local
 
-!!! warning "Aviso sobre Arquitetura (Apple Silicon / ARM64)"
-    Os contêineres, especialmente o `worker`, devem rodar nativamente em `linux/arm64`. Configure `platform: linux/arm64` no `docker-compose.yml` para evitar emulação (Rosetta 2 / amd64), que causa gargalos severos de performance e estouro de memória durante a vetorização.
+!!! info "Arquitetura Nativa Multiplataforma"
+    A orquestração do Docker está configurada sem a diretiva rígida de `platform` no `docker-compose.yml`. Isso permite que o Docker monte e execute imagens nativas automaticamente para a arquitetura do seu sistema operacional host (ARM64 para chips Apple Silicon e AMD64 para PCs Intel/AMD com Windows/Linux), garantindo a máxima performance de processamento local sem lentidão de emulação.
 
 ### Passo 1 — Clonar o repositório
 
@@ -188,7 +185,7 @@ git checkout develop
 
 ### Passo 2 — Configurar o `.env`
 
-Crie o arquivo `.env` na raiz conforme a seção 3. Defina ao menos `SUPABASE_URL`, `SUPABASE_KEY`, `QDRANT_URL`, `QDRANT_API_KEY`, `LLM_PROVIDER` e `REDIS_URL`.
+Crie o arquivo `.env` na raiz conforme a seção 3. Defina ao menos `SUPABASE_URL`, `SUPABASE_KEY`, `QDRANT_URL`, `QDRANT_API_KEY`, `GEMINI_API_KEY` e `REDIS_URL`.
 
 ### Passo 3 — Subir o ambiente
 
@@ -208,7 +205,8 @@ A partir da segunda execução, o *Layer Caching* e o volume HuggingFace elimina
 Ao final, estarão disponíveis:
 
 - **Interface do usuário:** http://localhost:3000
-- **Documentação da API (Swagger):** http://localhost:8000/docs
+- **Documentação da API (Swagger):** http://localhost:8001/docs
+- **Portal de Documentação (MkDocs):** http://localhost:8002
 
 ### Passo 4 — Derrubar o ambiente
 
@@ -240,7 +238,23 @@ docker compose run --rm worker python main.py
 
 ---
 
-## 6. Restrições que Nunca Devem Ser Violadas
+## 6. Executar os Testes Automatizados via Docker
+
+O repositório possui contêineres específicos para testes unitários e de integração configurados sob o perfil `test` no `docker-compose.yml`. Eles rodam o `pytest` de forma isolada.
+
+Para executar os testes do Lado de Leitura (API):
+```bash
+docker compose --profile test run --rm test-api pytest tests/api tests/test_setup.py
+```
+
+Para executar os testes do Lado de Escrita (ETL / Worker):
+```bash
+docker compose --profile test run --rm test-worker pytest tests/etl
+```
+
+---
+
+## 7. Restrições que Nunca Devem Ser Violadas
 
 | Restrição | Razão |
 |---|---|
@@ -251,7 +265,7 @@ docker compose run --rm worker python main.py
 | Qdrant sem volume local | Banco vetorial externo — dados residem na nuvem, fora do escopo Docker |
 | Redis sem porta exposta no host | Canal interno — não acessível fora da orquestração |
 | Redis sem volume de persistência | Canal de sinalização efêmero |
-| Troca de provedor LLM apenas via `.env` | Sem alterações em Dockerfile ou `docker-compose.yml` |
+| Credenciais e chaves de API injetadas apenas via `.env` | Evita exposição de segredos no código ou no Docker |
 | Responsabilidade vetorial exclusiva do Qdrant | O pgvector (Supabase) não deve ser usado para embeddings — consistência do espaço vetorial |
 | Modelo de embedding fixo: `BAAI/bge-m3` | Consistência do espaço vetorial com dados já indexados no Qdrant |
 | Worker sem portas expostas no host | Isolamento do processamento pesado |

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
### Descrição do Pull Request

#### Descrição Geral

Este PR refatora e consolida o ambiente de desenvolvimento local via Docker Compose. O objetivo principal foi restabelecer e garantir o funcionamento do hot-reload (live reload) de forma 100% confiável em todos os serviços (Frontend, Backend e Documentação) para desenvolvedores utilizando diferentes sistemas operacionais (especialmente macOS e Windows), além de limpar e atualizar a documentação de execução técnica.

---

#### Alterações Realizadas

1. **Correção de Hot-Reload (Docker Volume Polling):**
   - **FastAPI:** Configurada a variável `WATCHFILES_FORCE_POLLING=true` e verificado o fallback para `StatReload` do Uvicorn, garantindo o monitoramento contínuo de arquivos Python.
   - **NextJS:** Adicionadas as variáveis `WATCHPACK_POLLING=true` e `CHOKIDAR_USEPOLLING=true` para forçar o Webpack a escanear alterações de arquivos via polling.
   - **MkDocs (`docs`):** Adicionada a variável `MKDOCS_WATCHDOG_USE_POLLING=true` para forçar o monitoramento por polling da biblioteca `watchdog` no contêiner.

2. **Estabilização da Versão do MkDocs:**
   - Fixada a imagem do MkDocs na versão estável `squidfunk/mkdocs-material:9.5.18` para evitar bugs conhecidos de recarregamento originados pela biblioteca `click >= 8.3.0` em versões mais recentes.

3. **Atualização e Limpeza da Documentação (`execucao.md`):**
   - Removidas referências obsoletas a provedores de LLM que não são mais utilizados no escopo do projeto (`groq`, `ollama` e `colab`), consolidando o uso da Gemini API.
   - Corrigido o mapeamento de portas na tabela informativa de contêineres: a porta exposta do FastAPI foi atualizada de `8000` para `8001` no host, eliminando conflitos e alinhando com a orquestração do `docker-compose.yml`.

---

#### Como Testar as Modificações

1. Suba os contêineres do projeto com `docker compose up -d`.
2. Abra a documentação em http://localhost:8002/execucao/ (se necessário, faça um hard refresh com `Cmd+Shift+R` para limpar caches de assets de compilações antigas).
3. Faça uma modificação em `execucao.md` e salve o arquivo. Verifique o reload automático da aba.
4. Repita a validação para o frontend modificando o componente `Hero.tsx` acessando o endereço http://localhost:3000.

#### Responsáveis 

@lucasaraujoszz  @matheus0346 