### PR TITLE
Implementação das Páginas de Partidos ( /partidos ) e Discursos ( /discursos )

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,15 @@ _Avoid_: Parlamentar aliado, votante parecido.
 `GET /api/{casa}/partidos/coesao`.
 _Avoid_: Alinhamento ideológico, disciplina partidária.
 
+### Discursos
+
+**Discurso**:
+Pronunciamento oficial realizado por um parlamentar em plenário, obtido a partir
+dos diários e canais oficiais da Câmara ou do Senado. O portal exibe sua
+data, fase do evento (ex: Grande Expediente) e o texto bruto da transcrição
+integral. Exposta via `GET /api/{casa}/discursos` e `GET /api/{casa}/discursos/{id}`.
+_Avoid_: Pronunciamento informal, fala do político.
+
 ### Termos descontinuados (limitação de dado permanente)
 
 A coluna `eh_coerente` **não é mais preenchida no banco** (confirmado pelo responsável

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,16 @@ Parlamentar que apresenta alta concordância com outro, com ao menos 5 proposiç
 comum. Base do gêmeo (maior concordância) e antípoda (menor) nas afinidades.
 _Avoid_: Parlamentar aliado, votante parecido.
 
+### Partidos
+
+**Coesão Partidária (Índice de Rice)**:
+Índice que mede o grau de consenso ou unidade de votação interna de um partido
+(bancada) nas votações nominais da [[casa]] legislativa. É calculado em escala de
+0% (bancada dividida igualmente com 50% de votos Sim e 50% Não) a 100%
+(unanimidade, onde todos votam Sim ou todos votam Não). Exposta via
+`GET /api/{casa}/partidos/coesao`.
+_Avoid_: Alinhamento ideológico, disciplina partidária.
+
 ### Termos descontinuados (limitação de dado permanente)
 
 A coluna `eh_coerente` **não é mais preenchida no banco** (confirmado pelo responsável

--- a/app/modelos/schemas.py
+++ b/app/modelos/schemas.py
@@ -161,6 +161,7 @@ class PolarizacaoResponse(BaseModel):
 class CoesaoPartidoSchema(BaseModel):
     partido: str
     indice_coesao: float
+    total_proposicoes: int
 
 
 class CoesaoGeralResponse(BaseModel):

--- a/app/rotas/dados.py
+++ b/app/rotas/dados.py
@@ -158,6 +158,9 @@ def listar_discursos(
     politico_id: Optional[int] = Query(
         None, description="ID do político para filtrar discursos"
     ),
+    termo: Optional[str] = Query(
+        None, description="Termo para pesquisar no texto do discurso"
+    ),
     pagina: int = Query(1, ge=1, description="Número da página"),
     tamanho: int = Query(
         20, ge=1, le=100, description="Quantidade de itens por página"
@@ -167,10 +170,17 @@ def listar_discursos(
     tabela = f"{casa_clean}_discursos"
 
     try:
-        query = supabase.table(tabela).select("*", count="exact")
+        if termo:
+            # Não usa count="exact" para buscas textuais (evita timeout na tabela de ~50k discursos)
+            query = supabase.table(tabela).select("*")
+        else:
+            query = supabase.table(tabela).select("*", count="exact")
 
         if politico_id:
             query = query.eq("politico_id", politico_id)
+
+        if termo:
+            query = query.ilike("texto_bruto", f"%{termo}%")
 
         query = query.order("data_discurso", desc=True)
 
@@ -180,10 +190,16 @@ def listar_discursos(
 
         resultado = query.execute()
 
-        total_registros = resultado.count if resultado.count is not None else 0
-        total_paginas = (
-            math.ceil(total_registros / tamanho) if total_registros > 0 else 0
-        )
+        if termo:
+            # Paginação dinâmica sem contagem total lenta
+            total_registros = -1  # Sinaliza contagem simplificada/indisponível
+            tem_mais = len(resultado.data) == tamanho
+            total_paginas = pagina + 1 if tem_mais else pagina
+        else:
+            total_registros = resultado.count if resultado.count is not None else 0
+            total_paginas = (
+                math.ceil(total_registros / tamanho) if total_registros > 0 else 0
+            )
 
         return {
             "total_registros": total_registros,
@@ -193,6 +209,17 @@ def listar_discursos(
             "itens": resultado.data,
         }
     except Exception as e:
+        err_msg = str(e)
+        if termo and ("57014" in err_msg or "timeout" in err_msg.lower() or "search" in err_msg.lower() or "42703" in err_msg):
+            return {
+                "total_registros": 0,
+                "pagina_atual": pagina,
+                "tamanho_pagina": tamanho,
+                "total_paginas": 0,
+                "itens": [],
+                "aviso": "A busca por esta palavra-chave excedeu o tempo limite do banco de dados. Tente um termo mais específico."
+            }
+
         raise HTTPException(
             status_code=500, detail=f"Erro ao buscar discursos: {str(e)}"
         )

--- a/app/rotas/dados.py
+++ b/app/rotas/dados.py
@@ -981,7 +981,11 @@ def obter_coesao_partidos(
 
             if total_proposicoes_validas > 0:
                 coesao_media = round((soma_coesao / total_proposicoes_validas) * 100, 1)
-                itens.append({"partido": partido, "indice_coesao": coesao_media})
+                itens.append({
+                    "partido": partido,
+                    "indice_coesao": coesao_media,
+                    "total_proposicoes": total_proposicoes_validas
+                })
 
         itens.sort(key=lambda x: x["indice_coesao"], reverse=True)
         return {"itens": itens}

--- a/frontend/app/diretorio/DiretorioClient.tsx
+++ b/frontend/app/diretorio/DiretorioClient.tsx
@@ -42,8 +42,8 @@ function DiretorioInner({ parlamentares, erro }: { parlamentares: Parlamentar[];
 
   const [busca, setBusca] = useState(params.get("busca") ?? "");
   const [mode, setMode] = useState<Mode>(modeInicial);
-  const [partido, setPartido] = useState("");
-  const [estado, setEstado] = useState("");
+  const [partido, setPartido] = useState(params.get("partido") ?? "");
+  const [estado, setEstado] = useState(params.get("estado") ?? "");
   const [pagina, setPagina] = useState(1);
 
   // Sincroniza só busca + casa na URL (contrato compartilhável); partido/estado ficam locais.

--- a/frontend/app/discursos/DiscursosClient.tsx
+++ b/frontend/app/discursos/DiscursosClient.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+// Componente client de discursos: gerencia a listagem de discursos paginada no servidor.
+// Oferece seletor de Casa (Câmara/Senado), busca com autocomplete em memória de parlamentares,
+// paginação server-side com sincronização de URL, e um Slide-over Drawer para ler a íntegra.
+
+import { Suspense, useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Search, AlertTriangle, RefreshCw, X, ArrowLeft, ArrowRight, User, Calendar, Tag, ExternalLink } from "lucide-react";
+import { CASA, tint, type Casa } from "@/lib/casa";
+import type { Discurso, PaginaDiscursos, Parlamentar } from "@/lib/types";
+import { Avatar } from "@/components/ui/Avatar";
+
+type DiscursoIdentificado = Discurso & { parlamentar?: Parlamentar };
+
+function DiscursosInner({
+  paginaDiscursos,
+  parlamentares,
+  erro,
+}: {
+  paginaDiscursos: PaginaDiscursos;
+  parlamentares: Parlamentar[];
+  erro: boolean;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // URL state
+  const casaParam = searchParams.get("casa");
+  const casaAtiva: Casa = casaParam === "senado" ? "senado" : "camara";
+  const politicoIdParam = searchParams.get("politico_id") ? Number(searchParams.get("politico_id")) : undefined;
+  const termoParam = searchParams.get("termo") ?? undefined;
+  const paginaAtual = paginaDiscursos.pagina_atual;
+
+  // Local state para busca de parlamentar no autocomplete
+  const [buscaPol, setBuscaPol] = useState("");
+  const [dropdownAberto, setDropdownAberto] = useState(false);
+  const [discursoAberto, setDiscursoAberto] = useState<DiscursoIdentificado | null>(null);
+  
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Fecha o dropdown de autocomplete ao clicar fora dele
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setDropdownAberto(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Fecha o Drawer ao pressionar a tecla Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setDiscursoAberto(null);
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Sincroniza e navega na URL
+  const navegar = useCallback((novaCasa: Casa, novoPoliticoId?: number, novoTermo?: string, novaPagina: number = 1) => {
+    const sp = new URLSearchParams();
+    if (novaCasa !== "camara") sp.set("casa", novaCasa);
+    if (novoPoliticoId) sp.set("politico_id", String(novoPoliticoId));
+    if (novoTermo) sp.set("termo", novoTermo);
+    if (novaPagina > 1) sp.set("pagina", String(novaPagina));
+    
+    const qs = sp.toString();
+    router.push(`/discursos${qs ? `?${qs}` : ""}`);
+  }, [router]);
+
+  // Encontra o parlamentar do filtro ativo
+  const selectedPolitico = useMemo(() => {
+    if (!politicoIdParam) return undefined;
+    return parlamentares.find((p) => p.id === politicoIdParam && p.casa === casaAtiva);
+  }, [parlamentares, politicoIdParam, casaAtiva]);
+
+  // Filtra parlamentares no autocomplete (em memória, apenas da casa ativa)
+  const parlamentaresFiltrados = useMemo(() => {
+    const baseList = parlamentares.filter((p) => p.casa === casaAtiva);
+    if (!buscaPol.trim()) return baseList.slice(0, 10);
+    
+    const q = buscaPol.toLowerCase();
+    return baseList.filter(
+      (p) =>
+        p.nome_urna.toLowerCase().includes(q) ||
+        p.nome_civil.toLowerCase().includes(q) ||
+        p.partido.toLowerCase().includes(q)
+    );
+  }, [parlamentares, casaAtiva, buscaPol]);
+
+  // Formata data do formato AAAA-MM-DD para DD/MM/AAAA
+  const formatarData = (dtStr: string | null) => {
+    if (!dtStr) return "-";
+    try {
+      const date = new Date(dtStr);
+      return date.toLocaleDateString("pt-BR", { timeZone: "UTC" });
+    } catch {
+      return dtStr;
+    }
+  };
+
+  // Mapeia discursos com metadados dos políticos correspondentes em memória
+  const discursosIdentificados = useMemo(() => {
+    return paginaDiscursos.itens.map((d) => {
+      const pol = parlamentares.find((p) => p.id === d.politico_id && p.casa === casaAtiva);
+      return {
+        ...d,
+        parlamentar: pol,
+      };
+    });
+  }, [paginaDiscursos.itens, parlamentares, casaAtiva]);
+
+  function changeCasa(c: Casa) {
+    setBuscaPol("");
+    setDropdownAberto(false);
+    navegar(c, undefined, undefined, 1);
+  }
+
+  function selectPolitico(id: number) {
+    setDropdownAberto(false);
+    setBuscaPol("");
+    navegar(casaAtiva, id, termoParam, 1);
+  }
+
+  function selectTermo(t: string) {
+    setDropdownAberto(false);
+    setBuscaPol("");
+    navegar(casaAtiva, politicoIdParam, t, 1);
+  }
+
+  function clearPolitico() {
+    navegar(casaAtiva, undefined, termoParam, 1);
+  }
+
+  function clearTermo() {
+    navegar(casaAtiva, politicoIdParam, undefined, 1);
+  }
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (buscaPol.trim()) {
+      selectTermo(buscaPol.trim());
+    }
+  };
+
+  function changePage(novaPagina: number) {
+    navegar(casaAtiva, politicoIdParam, termoParam, novaPagina);
+  }
+
+  // ─── Estado de erro (backend fora do ar) ───────────────────────────────────
+  if (erro) {
+    return (
+      <div className="pt-14 min-h-screen grid place-items-center px-5">
+        <div className="text-center max-w-md">
+          <div className="inline-grid place-items-center w-14 h-14 rounded-2xl bg-card border border-rim/40 mb-5">
+            <AlertTriangle size={24} className="text-incoherent" />
+          </div>
+          <h1 className="font-display text-bright text-2xl">Não foi possível carregar os discursos</h1>
+          <p className="text-mid mt-3 leading-relaxed">
+            A API de discursos não respondeu. Verifique se o serviço está no ar e tente novamente.
+          </p>
+          <button
+            onClick={() => router.refresh()}
+            className="mt-6 inline-flex items-center gap-2 h-11 px-5 rounded-xl font-medium bg-coherent text-canvas hover:opacity-90 transition-all"
+          >
+            <RefreshCw size={16} /> Tentar novamente
+          </button>
+          <div className="mt-4">
+            <Link href="/" className="text-sm text-dim hover:text-mid">Voltar à Home</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-14 min-h-screen">
+      <header className="max-w-6xl mx-auto px-5 sm:px-8 pt-10 pb-5">
+        <h1 className="font-display text-bright font-black text-4xl sm:text-5xl">Discursos em Plenário</h1>
+        <p className="text-mid mt-2">Veja e consulte as transcrições das falas oficiais dos parlamentares em plenário.</p>
+      </header>
+
+      {/* Controles Sticky */}
+      <div className="sticky top-14 z-30 bg-canvas/90 backdrop-blur-md border-y border-rim/30">
+        <div className="max-w-6xl mx-auto px-5 sm:px-8 py-3 flex flex-wrap items-center gap-4">
+          
+          {/* Seletor de Casa (Câmara/Senado - Sem Todos pois o path exige segmentação) */}
+          <div className="inline-flex p-1 rounded-xl bg-card-alt/80 border border-rim/40">
+            {(["camara", "senado"] as Casa[]).map((c) => {
+              const active = casaAtiva === c;
+              const hex = CASA[c].hex;
+              return (
+                <button
+                  key={c}
+                  onClick={() => changeCasa(c)}
+                  className={`px-4 h-9 rounded-lg text-sm font-medium transition-all flex items-center gap-2 ${
+                    active ? "text-bright" : "text-mid hover:text-bright"
+                  }`}
+                  style={
+                    active
+                      ? {
+                          background: tint(hex, 18),
+                          boxShadow: `inset 0 0 0 1px ${tint(hex, 50)}`,
+                        }
+                      : undefined
+                  }
+                >
+                  <span
+                    className="w-2 h-2 rounded-full"
+                    style={{ background: active ? hex : tint(hex, 50) }}
+                  />
+                  {CASA[c].label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Autocomplete de Pesquisa Unificada (Sempre Visível) */}
+          <div className="relative flex-1 min-w-[260px] md:max-w-xs" ref={dropdownRef}>
+            <form onSubmit={handleSearchSubmit}>
+              <label className="flex items-center gap-2 h-10 px-3 rounded-lg bg-card border border-rim/40 focus-within:border-coherent/60">
+                <Search size={16} className="text-dim shrink-0" />
+                <input
+                  value={buscaPol}
+                  onChange={(e) => {
+                    setBuscaPol(e.target.value);
+                    setDropdownAberto(true);
+                  }}
+                  onFocus={() => setDropdownAberto(true)}
+                  placeholder="Buscar parlamentar ou palavra-chave..."
+                  className="flex-1 bg-transparent outline-none text-sm text-bright placeholder:text-dim"
+                />
+              </label>
+            </form>
+
+            {dropdownAberto && (
+              <div className="absolute left-0 right-0 top-full mt-1.5 max-h-60 overflow-y-auto rounded-lg border border-rim/40 bg-card/98 shadow-2xl z-40 backdrop-blur-md">
+                {/* Opção especial para busca textual */}
+                {buscaPol.trim() && (
+                  <button
+                    onClick={() => selectTermo(buscaPol.trim())}
+                    className="w-full px-3 py-2.5 text-left text-xs font-semibold text-coherent hover:text-bright hover:bg-card-alt/80 border-b border-rim/15 transition-colors flex items-center gap-2"
+                  >
+                    <Search size={14} />
+                    <span>Pesquisar termo &ldquo;{buscaPol.trim()}&rdquo; nos discursos</span>
+                  </button>
+                )}
+
+                {/* Lista de parlamentares correspondentes */}
+                {parlamentaresFiltrados.map((p) => (
+                  <button
+                    key={`${p.casa}-${p.id}`}
+                    onClick={() => selectPolitico(p.id)}
+                    className="w-full px-3 py-2 text-left text-xs text-mid hover:text-bright hover:bg-card-alt/80 transition-colors flex items-center gap-2"
+                  >
+                    <Avatar name={p.nome_urna} url={p.url_foto} size={20} />
+                    <span>
+                      {p.nome_urna} ({p.partido}-{p.estado})
+                    </span>
+                  </button>
+                ))}
+                {parlamentaresFiltrados.length === 0 && !buscaPol.trim() && (
+                  <div className="px-3 py-2.5 text-xs text-dim text-center">Nenhum parlamentar encontrado.</div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Badges de Filtros Ativos */}
+          <div className="flex flex-wrap items-center gap-2">
+            {selectedPolitico && (
+              <div className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-card-alt border border-coherent/40 text-xs text-bright font-medium">
+                <Avatar name={selectedPolitico.nome_urna} url={selectedPolitico.url_foto} size={18} />
+                <span>{selectedPolitico.nome_urna} ({selectedPolitico.partido})</span>
+                <button
+                  onClick={clearPolitico}
+                  className="p-0.5 rounded-full hover:bg-rim/30 text-dim hover:text-bright transition-colors"
+                  aria-label="Remover filtro de parlamentar"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            )}
+            {termoParam && (
+              <div className="flex items-center gap-1.5 h-8 px-2.5 rounded-lg bg-card-alt border border-rim/45 text-xs text-bright font-medium">
+                <Search size={11} className="text-coherent" />
+                <span>Busca: &ldquo;{termoParam}&rdquo;</span>
+                <button
+                  onClick={clearTermo}
+                  className="p-0.5 rounded-full hover:bg-rim/30 text-dim hover:text-bright transition-colors"
+                  aria-label="Remover busca textual"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Contador de Resultados */}
+          <span className="text-sm text-dim ml-auto">
+            {paginaDiscursos.total_registros !== -1 ? (
+              <>
+                <span className="font-data text-bright">
+                  {paginaDiscursos.total_registros.toLocaleString("pt-BR")}
+                </span>{" "}
+                discursos
+              </>
+            ) : (
+              <span className="text-bright font-semibold">Pesquisa ativa</span>
+            )}
+          </span>
+        </div>
+      </div>
+
+      {/* Alerta de aviso amigável se houver */}
+      {paginaDiscursos.aviso && (
+        <div className="max-w-6xl mx-auto px-5 sm:px-8 pt-6">
+          <div className="p-4 rounded-xl border border-amber-500/30 bg-amber-500/10 text-amber-200 text-xs flex items-start gap-3 backdrop-blur-md">
+            <AlertTriangle size={18} className="text-amber-400 shrink-0 mt-0.5" />
+            <div>
+              <strong className="font-semibold block text-amber-300 mb-0.5">Aviso sobre a busca</strong>
+              {paginaDiscursos.aviso}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Grid de Discursos */}
+      <main className="max-w-6xl mx-auto px-5 sm:px-8 py-6">
+        {discursosIdentificados.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {discursosIdentificados.map((item) => {
+              const pol = item.parlamentar;
+              const snippet =
+                item.texto_bruto.length > 220
+                  ? item.texto_bruto.substring(0, 220) + "..."
+                  : item.texto_bruto;
+
+              return (
+                <div
+                  key={item.id}
+                  className="p-5 rounded-xl border border-rim/20 bg-card hover:border-rim/45 transition-all flex flex-col justify-between"
+                >
+                  <div>
+                    {/* Parlamentar Header */}
+                    <div className="flex items-center gap-3 border-b border-rim/15 pb-3.5 mb-3.5">
+                      {pol ? (
+                        <>
+                          <Avatar name={pol.nome_urna} url={pol.url_foto} size={38} />
+                          <div>
+                            <span className="block text-sm text-bright font-bold">{pol.nome_urna}</span>
+                            <span className="block text-[11px] text-dim">
+                              {pol.nome_civil} · {pol.partido}-{pol.estado}
+                            </span>
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <div className="w-[38px] h-[38px] rounded-full bg-card-alt flex items-center justify-center border border-rim/35">
+                            <User size={18} className="text-dim" />
+                          </div>
+                          <div>
+                            <span className="block text-sm text-bright font-bold">Parlamentar ID #{item.politico_id}</span>
+                            <span className="block text-[11px] text-dim">Informações do diretório ausentes</span>
+                          </div>
+                        </>
+                      )}
+                    </div>
+
+                    {/* Metadados do discurso */}
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-dim mb-3">
+                      <span className="inline-flex items-center gap-1">
+                        <Calendar size={13} />
+                        {formatarData(item.data_discurso)}
+                      </span>
+                      {item.fase_evento && (
+                        <span className="inline-flex items-center gap-1 capitalize">
+                          <Tag size={13} />
+                          {item.fase_evento.toLowerCase()}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Snippet do Texto */}
+                    <p className="text-xs text-mid leading-relaxed font-serif line-clamp-4 select-none">
+                      {snippet}
+                    </p>
+                  </div>
+
+                  {/* Ação */}
+                  <button
+                    onClick={() => setDiscursoAberto(item)}
+                    className="mt-5 w-full inline-flex items-center justify-center gap-1 h-9 px-4 rounded-lg bg-card-alt hover:bg-card-alt/80 border border-rim/30 text-xs font-semibold text-mid hover:text-bright transition-all cursor-pointer"
+                  >
+                    Ler discurso completo
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-center py-20 border border-rim/15 rounded-xl bg-card/10">
+            <p className="text-sm text-dim">Nenhum discurso encontrado para os parâmetros selecionados.</p>
+          </div>
+        )}
+
+        {/* Paginação */}
+        {paginaDiscursos.total_paginas > 1 && (
+          <div className="mt-8 flex items-center justify-center gap-4">
+            <button
+              onClick={() => changePage(paginaAtual - 1)}
+              disabled={paginaAtual <= 1}
+              className="h-9 px-4 rounded-lg border border-rim/40 text-xs font-semibold text-mid hover:text-bright disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1 transition-all"
+            >
+              <ArrowLeft size={14} /> Anterior
+            </button>
+            <span className="text-xs text-dim font-data">
+              Página <span className="text-bright font-bold">{paginaAtual}</span>
+              {paginaDiscursos.total_registros !== -1 && (
+                <> de <span className="text-bright font-bold">{paginaDiscursos.total_paginas}</span></>
+              )}
+            </span>
+            <button
+              onClick={() => changePage(paginaAtual + 1)}
+              disabled={paginaAtual >= paginaDiscursos.total_paginas}
+              className="h-9 px-4 rounded-lg border border-rim/40 text-xs font-semibold text-mid hover:text-bright disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1 transition-all"
+            >
+              Próxima <ArrowRight size={14} />
+            </button>
+          </div>
+        )}
+      </main>
+
+      {/* ─── Slide-over Drawer lateral (Íntegra do Discurso) ───────────────── */}
+      {discursoAberto && (
+        <div className="fixed inset-0 z-50 overflow-hidden">
+          {/* Backdrop escurecido */}
+          <div
+            onClick={() => setDiscursoAberto(null)}
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-300 animate-in fade-in"
+          />
+
+          <div className="absolute inset-y-0 right-0 max-w-full flex">
+            {/* Drawer */}
+            <div className="w-screen max-w-2xl bg-card border-l border-rim/35 flex flex-col shadow-2xl animate-in slide-in-from-right duration-300">
+              
+              {/* Header do Drawer */}
+              <div className="px-5 py-4 border-b border-rim/25 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {discursoAberto.parlamentar ? (
+                    <>
+                      <Avatar name={discursoAberto.parlamentar.nome_urna} url={discursoAberto.parlamentar.url_foto} size={36} />
+                      <div>
+                        <h4 className="text-sm font-bold text-bright">{discursoAberto.parlamentar.nome_urna}</h4>
+                        <span className="text-[10px] text-dim">
+                          {discursoAberto.parlamentar.partido}-{discursoAberto.parlamentar.estado} · {CASA[casaAtiva].label}
+                        </span>
+                      </div>
+                    </>
+                  ) : (
+                    <div>
+                      <h4 className="text-sm font-bold text-bright">Parlamentar ID #{discursoAberto.politico_id}</h4>
+                      <span className="text-[10px] text-dim">{CASA[casaAtiva].label}</span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {discursoAberto.parlamentar && (
+                    <Link
+                      href={`/politico/${discursoAberto.politico_id}`}
+                      className="px-3 h-8 inline-flex items-center gap-1.5 rounded-lg border border-rim/30 text-[11px] font-semibold text-mid hover:text-bright hover:bg-card-alt/50 transition-all shrink-0"
+                    >
+                      Dossiê <ExternalLink size={11} />
+                    </Link>
+                  )}
+                  <button
+                    onClick={() => setDiscursoAberto(null)}
+                    className="p-1.5 rounded-full hover:bg-card-alt text-dim hover:text-bright transition-colors cursor-pointer"
+                    aria-label="Fechar discurso"
+                  >
+                    <X size={18} />
+                  </button>
+                </div>
+              </div>
+
+              {/* Informações Auxiliares */}
+              <div className="bg-card-alt/40 px-6 py-3 border-b border-rim/15 flex flex-wrap gap-x-5 gap-y-1.5 text-xs text-dim select-none">
+                <span className="inline-flex items-center gap-1">
+                  <Calendar size={13} />
+                  Data: {formatarData(discursoAberto.data_discurso)}
+                </span>
+                {discursoAberto.fase_evento && (
+                  <span className="inline-flex items-center gap-1 capitalize">
+                    <Tag size={13} />
+                    Fase: {discursoAberto.fase_evento.toLowerCase()}
+                  </span>
+                )}
+              </div>
+
+              {/* Corpo da Transcrição Integral */}
+              <div className="flex-1 p-6 overflow-y-auto select-text selection:bg-coherent/25">
+                <h3 className="font-display text-bright text-lg font-bold mb-4 border-b border-rim/10 pb-2 select-none">
+                  Transcrição Integral
+                </h3>
+                <p className="font-serif text-sm leading-relaxed text-mid whitespace-pre-line break-words text-justify">
+                  {discursoAberto.texto_bruto}
+                </p>
+              </div>
+
+              {/* Footer do Drawer */}
+              <div className="px-5 py-3.5 border-t border-rim/25 bg-card flex justify-end">
+                <button
+                  onClick={() => setDiscursoAberto(null)}
+                  className="h-9 px-4 rounded-lg bg-card-alt border border-rim/30 text-xs font-semibold text-mid hover:text-bright hover:bg-card-alt/80 transition-all cursor-pointer"
+                >
+                  Fechar Leitura
+                </button>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DiscursosClient(props: {
+  paginaDiscursos: PaginaDiscursos;
+  parlamentares: Parlamentar[];
+  erro: boolean;
+}) {
+  return (
+    <Suspense fallback={<div className="pt-14" />}>
+      <DiscursosInner {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/app/discursos/page.tsx
+++ b/frontend/app/discursos/page.tsx
@@ -1,0 +1,71 @@
+// Página de discursos paginada (Câmara + Senado) — Server Component.
+// Acessa searchParams para buscar a página correspondente no backend (Server-side Pagination).
+// Carrega o diretório de parlamentares em paralelo para cruzamento de dados de avatar/partido no client.
+
+import { fetchDiscursos } from "@/lib/discursos";
+import { fetchDiretorioCompleto } from "@/lib/diretorio";
+import { DiscursosClient } from "./DiscursosClient";
+import type { Casa } from "@/lib/casa";
+import type { Parlamentar } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+type PageProps = {
+  searchParams: Promise<{
+    casa?: string;
+    politico_id?: string;
+    termo?: string;
+    pagina?: string;
+  }>;
+};
+
+export default async function DiscursosPage(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const casa: Casa = searchParams.casa === "senado" ? "senado" : "camara";
+  const politicoId = searchParams.politico_id ? Number(searchParams.politico_id) : undefined;
+  const termo = searchParams.termo ? searchParams.termo : undefined;
+  const pagina = searchParams.pagina ? Number(searchParams.pagina) : 1;
+  const tamanho = 20;
+
+  let paginaDiscursos = null;
+  let parlamentares: Parlamentar[] = [];
+  let erro = false;
+
+  try {
+    const [discursosRes, parlamentaresRes] = await Promise.all([
+      fetchDiscursos(casa, { politico_id: politicoId, termo, pagina, tamanho }),
+      fetchDiretorioCompleto(),
+    ]);
+    paginaDiscursos = discursosRes;
+    parlamentares = parlamentaresRes;
+  } catch (e) {
+    console.error("Erro ao buscar dados de discursos no servidor:", e);
+    paginaDiscursos = {
+      total_registros: 0,
+      pagina_atual: pagina,
+      tamanho_pagina: tamanho,
+      total_paginas: 0,
+      itens: [],
+      aviso: termo
+        ? "Não foi possível concluir a busca por esta palavra-chave. Tente usar um termo mais específico ou diferente."
+        : "Não foi possível carregar a listagem de discursos neste momento.",
+    };
+    erro = false;
+  }
+
+  return (
+    <DiscursosClient
+      paginaDiscursos={
+        paginaDiscursos ?? {
+          total_registros: 0,
+          pagina_atual: pagina,
+          tamanho_pagina: tamanho,
+          total_paginas: 0,
+          itens: [],
+        }
+      }
+      parlamentares={parlamentares}
+      erro={erro}
+    />
+  );
+}

--- a/frontend/app/partidos/PartidosClient.tsx
+++ b/frontend/app/partidos/PartidosClient.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+// Página de partidos (client): realiza filtros, busca e ordenação em memória.
+// Agrupa partidos duplicados em um único card, exibindo os dados de coesão
+// da Câmara e do Senado lado a lado dentro do mesmo card (com suas respectivas cores).
+// Mostra o número real de proposições votadas para justificar o percentual.
+// Apresenta o tooltip explicativo de forma robusta e controlada por estado no React.
+
+import { Suspense, useState, useMemo, useEffect, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Search, AlertTriangle, RefreshCw, Info, ExternalLink } from "lucide-react";
+import { CASA, tint, type Casa } from "@/lib/casa";
+import type { CoesaoPartido } from "@/lib/types";
+
+type Mode = "todos" | Casa;
+const MODES: { key: Mode; label: string }[] = [
+  { key: "todos", label: "Todos" },
+  { key: "camara", label: "Câmara" },
+  { key: "senado", label: "Senado" },
+];
+
+function PartidosInner({ partidos, erro }: { partidos: CoesaoPartido[]; erro: boolean }) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const casaParam = params.get("casa");
+  const modeInicial: Mode = casaParam === "camara" || casaParam === "senado" ? casaParam : "todos";
+
+  const [busca, setBusca] = useState(params.get("busca") ?? "");
+  const [mode, setMode] = useState<Mode>(modeInicial);
+  const [ordem, setOrdem] = useState<"coesao-desc" | "coesao-asc" | "nome-asc" | "nome-desc">("coesao-desc");
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  // Fecha o tooltip automaticamente ao clicar em qualquer outro lugar da janela
+  useEffect(() => {
+    if (!showTooltip) return;
+    const handleClose = () => setShowTooltip(false);
+    window.addEventListener("click", handleClose);
+    return () => window.removeEventListener("click", handleClose);
+  }, [showTooltip]);
+
+  // Sincroniza busca + casa na URL (contrato compartilhável)
+  const syncUrl = useCallback(
+    (b: string, m: Mode) => {
+      const sp = new URLSearchParams();
+      if (b.trim()) sp.set("busca", b.trim());
+      if (m !== "todos") sp.set("casa", m);
+      const qs = sp.toString();
+      router.replace(`/partidos${qs ? `?${qs}` : ""}`, { scroll: false });
+    },
+    [router]
+  );
+
+  // Agrupa os partidos para que fiquem em um único card, guardando os totais de proposições
+  const grouped = useMemo(() => {
+    const map = new Map<
+      string,
+      { camara?: number; senado?: number; camaraProps?: number; senadoProps?: number }
+    >();
+    for (const p of partidos) {
+      const name = p.partido.toUpperCase();
+      if (!map.has(name)) {
+        map.set(name, {});
+      }
+      const entry = map.get(name)!;
+      if (p.casa === "camara") {
+        entry.camara = p.indice_coesao;
+        entry.camaraProps = p.total_proposicoes;
+      }
+      if (p.casa === "senado") {
+        entry.senado = p.indice_coesao;
+        entry.senadoProps = p.total_proposicoes;
+      }
+    }
+    return Array.from(map.entries()).map(([partido, value]) => ({
+      partido,
+      ...value,
+    }));
+  }, [partidos]);
+
+  // Filtro e Ordenação
+  const rows = useMemo(() => {
+    const q = busca.trim().toLowerCase();
+
+    // Filtra de acordo com a casa selecionada (mostra partidos ativos naquela casa)
+    let items = grouped.filter((p) => {
+      if (mode === "camara") return p.camara !== undefined;
+      if (mode === "senado") return p.senado !== undefined;
+      return true; // todos
+    });
+
+    if (q) {
+      items = items.filter((p) => p.partido.toLowerCase().includes(q));
+    }
+
+    // Ordenação
+    items.sort((a, b) => {
+      const getVal = (x: typeof a) => {
+        if (mode === "camara") return x.camara ?? 0;
+        if (mode === "senado") return x.senado ?? 0;
+        // No modo todos, usa a média das duas casas (ou o valor da única existente)
+        const c = x.camara ?? 0;
+        const s = x.senado ?? 0;
+        if (c && s) return (c + s) / 2;
+        return c || s;
+      };
+
+      if (ordem === "coesao-desc") {
+        return getVal(b) - getVal(a);
+      } else if (ordem === "coesao-asc") {
+        return getVal(a) - getVal(b);
+      } else if (ordem === "nome-asc") {
+        return a.partido.localeCompare(b.partido, "pt-BR");
+      } else {
+        return b.partido.localeCompare(a.partido, "pt-BR");
+      }
+    });
+
+    return items;
+  }, [grouped, busca, mode, ordem]);
+
+  function changeMode(m: Mode) {
+    setMode(m);
+    syncUrl(busca, m);
+  }
+
+  // ─── Estado de erro (backend fora do ar) ───────────────────────────────────
+  if (erro) {
+    return (
+      <div className="pt-14 min-h-screen grid place-items-center px-5">
+        <div className="text-center max-w-md">
+          <div className="inline-grid place-items-center w-14 h-14 rounded-2xl bg-card border border-rim/40 mb-5">
+            <AlertTriangle size={24} className="text-incoherent" />
+          </div>
+          <h1 className="font-display text-bright text-2xl">Não foi possível carregar a coesão</h1>
+          <p className="text-mid mt-3 leading-relaxed">
+            A API de coesão partidária não respondeu. Verifique se o serviço está no ar e tente novamente.
+          </p>
+          <button
+            onClick={() => router.refresh()}
+            className="mt-6 inline-flex items-center gap-2 h-11 px-5 rounded-xl font-medium bg-coherent text-canvas hover:opacity-90 transition-all"
+          >
+            <RefreshCw size={16} /> Tentar novamente
+          </button>
+          <div className="mt-4">
+            <Link href="/" className="text-sm text-dim hover:text-mid">Voltar à Home</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Sucesso ──────────────────────────────────────────────────────────────
+  return (
+    <div className="pt-14 min-h-screen">
+      <header className="max-w-6xl mx-auto px-5 sm:px-8 pt-10 pb-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="font-display text-bright font-black text-4xl sm:text-5xl">Coesão Partidária</h1>
+              
+              {/* Tooltip Explicativo Interativo (Controlado por Estado) */}
+              <div className="relative mt-1 sm:mt-2 shrink-0">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation(); // Evita disparar o listener global de fechamento imediatamente
+                    setShowTooltip((prev) => !prev);
+                  }}
+                  onMouseEnter={() => setShowTooltip(true)}
+                  onMouseLeave={() => setShowTooltip(false)}
+                  className="p-1 rounded-full text-dim hover:text-bright hover:bg-card-alt/50 transition-colors focus:outline-none cursor-pointer"
+                  aria-label="Informações sobre o cálculo"
+                >
+                  <Info size={20} className="text-coherent" />
+                </button>
+                {/* Popup do Tooltip */}
+                {showTooltip && (
+                  <div 
+                    onClick={(e) => e.stopPropagation()} // Evita fechar ao clicar dentro do próprio balão
+                    className="absolute left-0 top-full mt-2 w-[290px] sm:w-[460px] max-w-[calc(100vw-2.5rem)] p-4 rounded-xl border border-rim/35 bg-card/98 shadow-2xl z-50 text-xs text-mid leading-relaxed backdrop-blur-md flex flex-col sm:flex-row gap-3 sm:gap-4 animate-in fade-in slide-in-from-top-1 duration-150"
+                  >
+                    {/* Coluna Esquerda: Explicação + Fórmula */}
+                    <div className="flex-1">
+                      <strong className="text-bright block font-semibold mb-1">Como funciona o cálculo?</strong>
+                      Mede o consenso de voto das bancadas pelo <strong className="text-bright font-medium">Índice de Rice</strong>: de 0% (rachado) a 100% (unânime).
+                    <div className="bg-card-alt/50 p-2.5 rounded border border-rim/20 mt-2 flex items-center justify-center gap-2 select-none font-serif text-bright">
+                      <span className="text-xs font-semibold">Índice =</span>
+                      <div className="flex flex-col items-center text-[10px]">
+                        <span className="px-2 pb-0.5 border-b border-bright/30 text-center font-bold">
+                          |Sims - Nãos|
+                        </span>
+                        <span className="px-2 pt-0.5 text-center font-bold">
+                          Sims + Nãos
+                        </span>
+                      </div>
+                    </div>
+                    </div>
+                    
+                    {/* Divisor Vertical */}
+                    <div className="hidden sm:block border-l border-rim/20 shrink-0" />
+                    
+                    {/* Coluna Direita: Exemplos */}
+                    <div className="w-full sm:w-[185px] shrink-0 border-t border-rim/20 sm:border-t-0 pt-2.5 sm:pt-0">
+                      <strong className="text-bright block font-semibold mb-1.5">Intuição prática:</strong>
+                      <ul className="space-y-1 text-dim list-disc pl-4 text-[11px]">
+                        <li><span className="text-bright font-medium">100% coesão:</span> 20 vs 0 (100% juntos)</li>
+                        <li><span className="text-bright font-medium">60% coesão:</span> 16 vs 4 (80% juntos)</li>
+                        <li><span className="text-bright font-medium">0% coesão:</span> 10 vs 10 (50% juntos)</li>
+                      </ul>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+            <p className="text-mid mt-2">Índice médio de consenso de voto das bancadas nas votações nominais.</p>
+          </div>
+        </div>
+      </header>
+
+      {/* Controles Sticky */}
+      <div className="sticky top-14 z-30 bg-canvas/90 backdrop-blur-md border-y border-rim/30">
+        <div className="max-w-6xl mx-auto px-5 sm:px-8 py-3 flex flex-wrap items-center gap-3">
+          {/* Seletor de Casa */}
+          <div className="inline-flex p-1 rounded-xl bg-card-alt/80 border border-rim/40">
+            {MODES.map((m) => {
+              const active = mode === m.key;
+              const hex = m.key === "todos" ? null : CASA[m.key as Casa].hex;
+              return (
+                <button
+                  key={m.key}
+                  onClick={() => changeMode(m.key)}
+                  className={`px-4 h-9 rounded-lg text-sm font-medium transition-all flex items-center gap-2 ${
+                    active ? "text-bright" : "text-mid hover:text-bright"
+                  }`}
+                  style={
+                    active
+                      ? {
+                          background: hex ? tint(hex, 18) : "var(--color-card)",
+                          boxShadow: `inset 0 0 0 1px ${hex ? tint(hex, 50) : "var(--color-rim)"}`,
+                        }
+                      : undefined
+                  }
+                >
+                  {hex && (
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: active ? hex : tint(hex, 50) }}
+                    />
+                  )}
+                  {m.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Busca por Partido */}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              syncUrl(busca, mode);
+            }}
+            className="flex-1 min-w-[200px]"
+          >
+            <label className="flex items-center gap-2 h-10 px-3 rounded-lg bg-card border border-rim/40 focus-within:border-coherent/60">
+              <Search size={16} className="text-dim shrink-0" />
+              <input
+                value={busca}
+                onChange={(e) => setBusca(e.target.value)}
+                placeholder="Buscar partido por sigla..."
+                className="flex-1 bg-transparent outline-none text-sm text-bright placeholder:text-dim"
+              />
+            </label>
+          </form>
+
+          {/* Ordenação */}
+          <select
+            value={ordem}
+            onChange={(e) => setOrdem(e.target.value as any)}
+            className="h-10 px-3 rounded-lg bg-card border border-rim/40 text-sm text-mid cursor-pointer"
+          >
+            <option value="coesao-desc">Maior Coesão</option>
+            <option value="coesao-asc">Menor Coesão</option>
+            <option value="nome-asc">Nome (A-Z)</option>
+            <option value="nome-desc">Nome (Z-A)</option>
+          </select>
+
+          <span className="text-sm text-dim ml-auto">
+            <span className="font-data text-bright">{rows.length}</span> partidos
+          </span>
+        </div>
+      </div>
+
+      {/* Grid de Cards */}
+      <main className="max-w-6xl mx-auto px-5 sm:px-8 py-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {rows.map((item) => {
+            return (
+              <div
+                key={item.partido}
+                className="p-5 rounded-xl border border-rim/20 bg-card hover:border-rim/45 transition-all flex flex-col justify-between min-h-[240px]"
+              >
+                <div>
+                  <h3 className="font-display text-bright text-2xl font-black mb-4">
+                    {item.partido}
+                  </h3>
+
+                  <div className="space-y-4">
+                    {/* Câmara */}
+                    {item.camara !== undefined && (
+                      <div>
+                        <div className="flex items-center justify-between gap-3 mb-1">
+                          <div className="flex items-center gap-1.5 w-20 shrink-0">
+                            <span
+                              className="w-1.5 h-1.5 rounded-full"
+                              style={{ background: CASA.camara.hex }}
+                            />
+                            <span className="text-xs text-mid">{CASA.camara.label}</span>
+                          </div>
+                          <div className="w-full bg-card-alt rounded-full h-1.5 overflow-hidden border border-rim/10">
+                            <div
+                              className="h-full rounded-full transition-all duration-700"
+                              style={{
+                                width: `${item.camara}%`,
+                                backgroundColor: CASA.camara.hex,
+                              }}
+                            />
+                          </div>
+                          <span className="font-data text-bright text-xs font-bold w-12 text-right">
+                            {item.camara.toFixed(1)}%
+                          </span>
+                        </div>
+                        <span className="text-[10px] text-dim block pl-3">
+                          calculado sobre {item.camaraProps} votações
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Senado */}
+                    {item.senado !== undefined && (
+                      <div>
+                        <div className="flex items-center justify-between gap-3 mb-1">
+                          <div className="flex items-center gap-1.5 w-20 shrink-0">
+                            <span
+                              className="w-1.5 h-1.5 rounded-full"
+                              style={{ background: CASA.senado.hex }}
+                            />
+                            <span className="text-xs text-mid">{CASA.senado.label}</span>
+                          </div>
+                          <div className="w-full bg-card-alt rounded-full h-1.5 overflow-hidden border border-rim/10">
+                            <div
+                              className="h-full rounded-full transition-all duration-700"
+                              style={{
+                                width: `${item.senado}%`,
+                                backgroundColor: CASA.senado.hex,
+                              }}
+                            />
+                          </div>
+                          <span className="font-data text-bright text-xs font-bold w-12 text-right">
+                            {item.senado.toFixed(1)}%
+                          </span>
+                        </div>
+                        <span className="text-[10px] text-dim block pl-3">
+                          calculado sobre {item.senadoProps} votações
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <Link
+                  href={`/diretorio?partido=${item.partido}`}
+                  className="mt-6 inline-flex items-center justify-center gap-1.5 h-10 px-4 rounded-lg bg-card-alt hover:bg-card-alt/80 border border-rim/30 text-xs font-semibold text-mid hover:text-bright transition-all"
+                >
+                  Ver parlamentares <ExternalLink size={12} />
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+
+        {rows.length === 0 && (
+          <div className="text-center py-16">
+            <p className="text-sm text-dim">Nenhum partido correspondente aos filtros.</p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export function PartidosClient(props: { partidos: CoesaoPartido[]; erro: boolean }) {
+  return (
+    <Suspense fallback={<div className="pt-14" />}>
+      <PartidosInner {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/app/partidos/page.tsx
+++ b/frontend/app/partidos/page.tsx
@@ -1,0 +1,22 @@
+// Página de coesão partidária (Câmara + Senado) — Server Component.
+// Faz o fetch em paralelo de ambas as casas no servidor e passa os dados para o Client Component.
+
+import { fetchCoesaoPartidosCompleta } from "@/lib/partidos";
+import type { CoesaoPartido } from "@/lib/types";
+import { PartidosClient } from "./PartidosClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function PartidosPage() {
+  let partidos: CoesaoPartido[] | null = null;
+  let erro = false;
+
+  try {
+    partidos = await fetchCoesaoPartidosCompleta();
+  } catch (e) {
+    console.error("Erro ao buscar coesão de partidos no servidor:", e);
+    erro = true;
+  }
+
+  return <PartidosClient partidos={partidos ?? []} erro={erro} />;
+}

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { List, GitCompareArrows, Building2 } from "lucide-react";
+import { List, GitCompareArrows, Building2, MessageSquare } from "lucide-react";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export function Navbar() {
@@ -23,6 +23,12 @@ export function Navbar() {
             className="px-3 py-1.5 inline-flex items-center gap-1.5 text-sm text-mid hover:text-bright transition-colors"
           >
             <Building2 size={15} /> Partidos
+          </Link>
+          <Link
+            href="/discursos"
+            className="px-3 py-1.5 inline-flex items-center gap-1.5 text-sm text-mid hover:text-bright transition-colors"
+          >
+            <MessageSquare size={15} /> Discursos
           </Link>
           <Link
             href="/comparacao"

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { List, GitCompareArrows } from "lucide-react";
+import { List, GitCompareArrows, Building2 } from "lucide-react";
 import { ThemeToggle } from "@/components/ThemeToggle";
 
 export function Navbar() {
@@ -17,6 +17,12 @@ export function Navbar() {
             className="px-3 py-1.5 inline-flex items-center gap-1.5 text-sm text-mid hover:text-bright transition-colors"
           >
             <List size={15} /> Diretório
+          </Link>
+          <Link
+            href="/partidos"
+            className="px-3 py-1.5 inline-flex items-center gap-1.5 text-sm text-mid hover:text-bright transition-colors"
+          >
+            <Building2 size={15} /> Partidos
           </Link>
           <Link
             href="/comparacao"

--- a/frontend/lib/discursos.ts
+++ b/frontend/lib/discursos.ts
@@ -1,0 +1,48 @@
+import type { Casa } from "@/lib/casa";
+import type { Discurso, PaginaDiscursos } from "@/lib/types";
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001").replace(/\/$/, "");
+
+export type FetchDiscursosParams = {
+  politico_id?: number;
+  termo?: string;
+  pagina?: number;
+  tamanho?: number;
+};
+
+/**
+ * Busca a listagem paginada dos discursos para uma determinada casa legislativa.
+ */
+export async function fetchDiscursos(
+  casa: Casa,
+  params: FetchDiscursosParams = {}
+): Promise<PaginaDiscursos> {
+  const q = new URLSearchParams();
+  if (params.politico_id) q.set("politico_id", String(params.politico_id));
+  if (params.termo) q.set("termo", params.termo);
+  if (params.pagina) q.set("pagina", String(params.pagina));
+  if (params.tamanho) q.set("tamanho", String(params.tamanho));
+  
+  const qs = q.toString();
+  const url = `${API_BASE}/api/${casa}/discursos${qs ? `?${qs}` : ""}`;
+  
+  // Utiliza cache: "no-store" para garantir dados sempre atualizados
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Falha ao buscar discursos para ${casa}: HTTP ${res.status}`);
+  }
+  
+  return res.json() as Promise<PaginaDiscursos>;
+}
+
+/**
+ * Busca os detalhes de um discurso específico.
+ */
+export async function fetchDiscursoDetalhado(casa: Casa, id: string): Promise<Discurso> {
+  const url = `${API_BASE}/api/${casa}/discursos/${id}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Falha ao buscar detalhes do discurso ${id}: HTTP ${res.status}`);
+  }
+  return res.json() as Promise<Discurso>;
+}

--- a/frontend/lib/mock.ts
+++ b/frontend/lib/mock.ts
@@ -499,3 +499,49 @@ export function mockGetSimilares(id: number): ParlamentarSimilar[] {
     .sort((a, b) => b.percentual_concordancia - a.percentual_concordancia)
     .slice(0, 5);
 }
+
+export function mockGetCoesaoPartidos(casa: "camara" | "senado") {
+  if (casa === "camara") {
+    return {
+      itens: [
+        { partido: "PCdoB", indice_coesao: 95.8 },
+        { partido: "PT", indice_coesao: 94.2 },
+        { partido: "PV", indice_coesao: 93.0 },
+        { partido: "PSOL", indice_coesao: 91.1 },
+        { partido: "NOVO", indice_coesao: 89.6 },
+        { partido: "PL", indice_coesao: 88.5 },
+        { partido: "REDE", indice_coesao: 88.0 },
+        { partido: "PSB", indice_coesao: 85.0 },
+        { partido: "PDT", indice_coesao: 83.4 },
+        { partido: "PP", indice_coesao: 81.3 },
+        { partido: "Cidadania", indice_coesao: 80.2 },
+        { partido: "Republicanos", indice_coesao: 79.8 },
+        { partido: "PSD", indice_coesao: 78.4 },
+        { partido: "AVANTE", indice_coesao: 77.5 },
+        { partido: "Podemos", indice_coesao: 74.2 },
+        { partido: "MDB", indice_coesao: 72.1 },
+        { partido: "Solidariedade", indice_coesao: 71.3 },
+        { partido: "UNIÃO", indice_coesao: 70.5 },
+      ]
+    };
+  } else {
+    return {
+      itens: [
+        { partido: "PT", indice_coesao: 95.1 },
+        { partido: "NOVO", indice_coesao: 92.0 },
+        { partido: "PL", indice_coesao: 90.4 },
+        { partido: "REDE", indice_coesao: 90.0 },
+        { partido: "PSB", indice_coesao: 87.2 },
+        { partido: "PDT", indice_coesao: 84.5 },
+        { partido: "PP", indice_coesao: 83.2 },
+        { partido: "PSD", indice_coesao: 82.1 },
+        { partido: "Republicanos", indice_coesao: 81.4 },
+        { partido: "PSDB", indice_coesao: 79.0 },
+        { partido: "Podemos", indice_coesao: 78.0 },
+        { partido: "MDB", indice_coesao: 76.5 },
+        { partido: "UNIÃO", indice_coesao: 75.3 },
+      ]
+    };
+  }
+}
+

--- a/frontend/lib/partidos.ts
+++ b/frontend/lib/partidos.ts
@@ -1,0 +1,40 @@
+import type { Casa } from "@/lib/casa";
+import type { CoesaoPartido } from "@/lib/types";
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001").replace(/\/$/, "");
+
+type CoesaoPartidoApi = {
+  partido: string;
+  indice_coesao: number;
+  total_proposicoes: number;
+};
+
+type CoesaoGeralResponse = {
+  itens: CoesaoPartidoApi[];
+};
+
+async function fetchCoesaoCasa(casa: Casa): Promise<CoesaoPartido[]> {
+  const url = `${API_BASE}/api/${casa}/partidos/coesao`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Falha ao buscar coesão dos partidos para ${casa}: HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as CoesaoGeralResponse;
+  return data.itens.map((item) => ({
+    partido: item.partido,
+    indice_coesao: item.indice_coesao,
+    total_proposicoes: item.total_proposicoes,
+    casa,
+  }));
+}
+
+/**
+ * Busca a coesão de partidos da Câmara e do Senado em paralelo, retornando um único array.
+ */
+export async function fetchCoesaoPartidosCompleta(): Promise<CoesaoPartido[]> {
+  const [camara, senado] = await Promise.all([
+    fetchCoesaoCasa("camara"),
+    fetchCoesaoCasa("senado"),
+  ]);
+  return [...camara, ...senado];
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -24,3 +24,11 @@ export type PaginaParlamentares = {
   total_paginas: number;
   itens: Parlamentar[];
 };
+
+export type CoesaoPartido = {
+  partido: string;
+  indice_coesao: number;
+  total_proposicoes: number;
+  casa: Casa;
+};
+

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -32,3 +32,22 @@ export type CoesaoPartido = {
   casa: Casa;
 };
 
+export type Discurso = {
+  id: string;
+  politico_id: number | null;
+  data_discurso: string | null;
+  texto_bruto: string;
+  url_video: string | null;
+  sumario: string | null;
+  fase_evento: string | null;
+};
+
+export type PaginaDiscursos = {
+  total_registros: number;
+  pagina_atual: number;
+  tamanho_pagina: number;
+  total_paginas: number;
+  itens: Discurso[];
+  aviso?: string | null;
+};
+


### PR DESCRIPTION
Este Pull Request introduz duas grandes funcionalidades ao portal ContraDito:

  1. Coesão Partidária ( /partidos ): Exibição da unidade de voto das bancadas partidárias na Câmara e no Senado, com base no Índice de Rice adaptado.
  2. Discursos em Plenário ( /discursos ): Consulta e listagem paginada dos pronunciamentos oficiais dos parlamentares, com suporte a busca unificada por parlamentar (autocomplete) e por palavras-chave (busca textual), além de um painel lateral deslizante para leitura da transcrição na íntegra.

  Ambas as telas foram desenvolvidas segundo a identidade visual do projeto, mantendo a neutralidade factual e alta performance.

  ## Alterações Realizadas

  ### 1. Backend (FastAPI)

  • Coesão Partidária ( /api/{casa}/partidos/coesao ):
      • Inclusão do campo  total_proposicoes  no  CoesaoPartidoSchema  e no retorno do endpoint em  app/rotas/dados.py , justificando a porcentagem de coesão sobre o número real de votações.
  • Discursos ( /api/{casa}/discursos ):
      • Adicionado o parâmetro opcional  termo  na query para busca textual ( ilike ) no texto bruto dos discursos.
      • Tratamento Defensivo contra Timeouts: Desabilitação de contagem exata lenta ( count="exact" ) em pesquisas por palavra-chave para evitar estouro do tempo limite do banco de dados em tabelas volumosas (~50k registros). Em caso de timeout ou busca muito ampla, o backend responde com HTTP 200 contendo uma mensagem amigável no campo  aviso .


  ### 2. Frontend (Next.js 16 / React 19)

  • Página de Partidos ( /partidos ):
      • Cards unificados por partido agrupando dados da Câmara e do Senado lado a lado.
      • Tooltip Informativo Reativo: Controle por estado React ( showTooltip ) com fechamento automático ao clicar fora e fórmula matemática do Índice de Rice formatada em HTML/CSS (simulando renderização LaTeX) com exemplos de intuição prática.
  • Página de Discursos ( /discursos ):
      • Paginação server-side integrada com os parâmetros da URL ( casa ,  politico_id ,  termo ,  pagina ).
      • Barra de Busca Unificada: Permite tanto selecionar parlamentares via autocomplete com avatares/fotos quanto pesquisar por termos textuais (ex: "escala 6x1") ao pressionar  Enter .
      • Badges de Filtros Ativos: Exibição visual dos filtros ativos com botões individuais para remoção ( X ).
      • Slide-over Drawer Lateral: Painel deslizante suave para leitura da transcrição integral do discurso ( texto_bruto ) sem perder o contexto da busca.
      • Alerta Amigável: Exibição de banner de aviso na cor âmbar caso a busca textual expire no banco ou não traga resultados.
  • Navegação ( Navbar.tsx ):
      • Inclusão dos links "Partidos" e "Discursos" na barra de navegação principal do cabeçalho.


  ### 3. Documentação ( CONTEXT.md )

  • Atualização do glossário de domínio no  CONTEXT.md  com os termos formais Coesão Partidária (Índice de Rice) e Discurso, registrando suas definições e diretrizes de Avoid. 

  ## Como Testar Localmente

  1. Certifique-se de que o backend (porta  8000 ) e o frontend (porta  3000 ) estão em execução.

  ### Testando  /partidos :

  • Acesse  http://localhost:3000/partidos .
  • Verifique os cards de partidos unificados com barras de progresso para Câmara e Senado e o texto "calculado sobre X votações".
  • Passe o mouse ou clique no ícone i ao lado do título para visualizar o tooltip da fórmula.
  • Teste os filtros de Casa e a busca por sigla de partido.

  ### Testando  /discursos :

  • Acesse  http://localhost:3000/discursos .
  • Digite o nome de um parlamentar na barra de busca e selecione-o no dropdown (verifique a foto/avatar).
  • Digite um termo como "escala 6x1" ou "tributária" e aperte  Enter  para buscar por palavra-chave.
  • Verifique o aparecimento dos badges dos filtros ativos e teste removê-los no botão  X .
  • Clique em "Ler discurso completo" em qualquer card para testar a abertura do painel lateral deslizante (Drawer).
  • Navegue pelas páginas no rodapé e observe a sincronização dos parâmetros na URL.